### PR TITLE
[WIP] Function label constraints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,12 @@ services:
             - "/var/run/docker.sock:/var/run/docker.sock"
         ports:
             - 8080:8080
-        image: functions/gateway:0.6.3
+        image: functions/gateway:latest-dev
         networks:
             - functions
         environment:
             dnsrr: "true"  # Temporarily use dnsrr in place of VIP while issue persists on PWD
+            faas_function_filters: "hello=world"
         deploy:
             placement:
                 constraints:
@@ -82,6 +83,8 @@ services:
             no_proxy: "gateway"
             https_proxy: $https_proxy
         deploy:
+            labels:
+                hello: "world"
             placement:
                 constraints:
                     - 'node.platform.os == linux'

--- a/gateway/handlers/reader.go
+++ b/gateway/handlers/reader.go
@@ -19,10 +19,13 @@ import (
 )
 
 // MakeFunctionReader gives a summary of Function structs with Docker service stats overlaid with Prometheus counters.
-func MakeFunctionReader(metricsOptions metrics.MetricOptions, c *client.Client) http.HandlerFunc {
+func MakeFunctionReader(metricsOptions metrics.MetricOptions, c *client.Client, serviceLabelFilters []string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		serviceFilter := filters.NewArgs()
+		for _, labelFilter := range serviceLabelFilters {
+			serviceFilter.Add("label", labelFilter)
+		}
 
 		options := types.ServiceListOptions{
 			Filters: serviceFilter,

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -95,7 +95,7 @@ func main() {
 		faasHandlers.Proxy = internalHandlers.MakeProxy(metricsOptions, true, dockerClient, &logger)
 		faasHandlers.RoutelessProxy = internalHandlers.MakeProxy(metricsOptions, true, dockerClient, &logger)
 		faasHandlers.Alert = internalHandlers.MakeAlertHandler(internalHandlers.NewSwarmServiceQuery(dockerClient))
-		faasHandlers.ListFunctions = internalHandlers.MakeFunctionReader(metricsOptions, dockerClient)
+		faasHandlers.ListFunctions = internalHandlers.MakeFunctionReader(metricsOptions, dockerClient, []string{})
 		faasHandlers.DeployFunction = internalHandlers.MakeNewFunctionHandler(metricsOptions, dockerClient, maxRestarts)
 		faasHandlers.DeleteFunction = internalHandlers.MakeDeleteFunctionHandler(metricsOptions, dockerClient)
 		// This could exist in a separate process - records the replicas of each swarm service.

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -95,7 +95,7 @@ func main() {
 		faasHandlers.Proxy = internalHandlers.MakeProxy(metricsOptions, true, dockerClient, &logger)
 		faasHandlers.RoutelessProxy = internalHandlers.MakeProxy(metricsOptions, true, dockerClient, &logger)
 		faasHandlers.Alert = internalHandlers.MakeAlertHandler(internalHandlers.NewSwarmServiceQuery(dockerClient))
-		faasHandlers.ListFunctions = internalHandlers.MakeFunctionReader(metricsOptions, dockerClient, []string{})
+		faasHandlers.ListFunctions = internalHandlers.MakeFunctionReader(metricsOptions, dockerClient, config.FunctionFilters)
 		faasHandlers.DeployFunction = internalHandlers.MakeNewFunctionHandler(metricsOptions, dockerClient, maxRestarts)
 		faasHandlers.DeleteFunction = internalHandlers.MakeDeleteFunctionHandler(metricsOptions, dockerClient)
 		// This could exist in a separate process - records the replicas of each swarm service.

--- a/gateway/types/readconfig.go
+++ b/gateway/types/readconfig.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -97,6 +98,9 @@ func (ReadConfig) Read(hasEnv HasEnv) GatewayConfig {
 		cfg.PrometheusHost = prometheusHost
 	}
 
+	funcFilters := hasEnv.Getenv("faas_function_filters")
+	cfg.FunctionFilters = strings.Split(funcFilters, ",")
+
 	return cfg
 }
 
@@ -109,6 +113,7 @@ type GatewayConfig struct {
 	NATSPort             *int
 	PrometheusHost       string
 	PrometheusPort       int
+	FunctionFilters      []string
 }
 
 // UseNATS Use NATSor not


### PR DESCRIPTION
A WIP implementation of Option E from #175 to allow service label filters to be configured on the gateway.

## Description

Add an environment config named `faas_function_filters` to the gateway. It is a comma-separated list of label filters used filter Docker services when reading the list of functions for the gateway. It is parsed into a string array and stored in a new field named `FunctionFilters` in `GatewayConfig`.

## Motivation and Context

When multiple gateways are deployed on a swarm, there is no way to configure gateways to pick up only certain functions. As a result, functions from different stacks or different deployments of the same stack “leak” into each other. This is a WIP implementation of one of the possible options for configuring the gateway to read only certain function services.

This implementation is for Option E in proposal issue #175, and aims to solve issue #55.

- [X] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

The `docker-compose.yml` file in this branch has been temporarily changed to filter for `hello=world`, and the `hubstats` function has been labeled to match. The gateway correctly picks up just that one function. If the `faas_function_filters` environment variable is removed, all the functions in the stack are read as before.

This currently breaks adding a new function in the UI, because the created service lacks the labels specified in `faas_function_filters`.

Also, this filtering is based on labels on services, not containers. It might be worth considering moving the `function` label to the service level for uniformity. However, that would be a breaking change.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This becomes a breaking change if the `function` label is moved to the service level.

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
