### PR TITLE
Sidenav toggle button

### DIFF
--- a/gateway/assets/img/icons/ic_arrow_back_white.svg
+++ b/gateway/assets/img/icons/ic_arrow_back_white.svg
@@ -1,0 +1,4 @@
+<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+</svg>

--- a/gateway/assets/img/icons/ic_menu_white.svg
+++ b/gateway/assets/img/icons/ic_menu_white.svg
@@ -1,0 +1,4 @@
+<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/>
+</svg>

--- a/gateway/assets/index.html
+++ b/gateway/assets/index.html
@@ -13,11 +13,24 @@
 <body ng-controller="home">
     <div layout="column" ng-cloak>
 
+        <md-toolbar class="md-theme-indigo" hide-gt-sm>
+            <div class="md-toolbar-tools">
+              <md-button ng-click="toggleSideNav()" class="md-icon-button" aria-label="Menu">
+                <md-icon md-svg-icon="img/icons/ic_menu_white.svg"></md-icon>
+              </md-button>
+            </div>
+        </md-toolbar>
         <section id="popupContainer" layout="row" flex>
             <md-sidenav class="md-sidenav-left" md-component-id="left" md-is-locked-open="$mdMedia('gt-sm')" md-whiteframe="4" layout="column">
 
                 <md-toolbar class="md-theme-indigo">
-                    <h1 class="md-toolbar-tools"><img src="icon.png" alt="OpenFaaS Icon" width="60px" height="60px" class="md-avatar"/>&nbsp; OpenFaaS Portal</h1>
+                    <div class="md-toolbar-tools">
+                      <img src="icon.png" alt="OpenFaaS Icon" width="60px" height="60px" class="md-avatar"/>
+                      <h1 style="flex: 1 1 auto;">&nbsp; OpenFaaS Portal</h1>
+                      <md-button ng-click="toggleSideNav()" class="md-icon-button" aria-label="Back" hide-gt-sm>
+                        <md-icon md-svg-icon="img/icons/ic_arrow_back_white.svg"></md-icon>
+                      </md-button>
+                    </div>
                 </md-toolbar>
 
                 <md-content layout-padding>

--- a/gateway/assets/script/bootstrap.js
+++ b/gateway/assets/script/bootstrap.js
@@ -4,14 +4,18 @@
 
 var app = angular.module('faasGateway', ['ngMaterial']);
 
-app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$mdDialog', '$mdToast',
-        function($scope, $log, $http, $location, $timeout, $mdDialog, $mdToast) {
+app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$mdDialog', '$mdToast', '$mdSidenav',
+        function($scope, $log, $http, $location, $timeout, $mdDialog, $mdToast, $mdSidenav) {
     $scope.functions = [];
     $scope.invocationRequest = "";
     $scope.invocationResponse = "";
     $scope.invocationStatus = "";
     $scope.invocation = {
         contentType: "text"
+    };
+
+    $scope.toggleSideNav = function() {
+        $mdSidenav('left').toggle();
     };
 
     $scope.functionTemplate = {


### PR DESCRIPTION
Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The current gateway UI's `sidenav` hides when the screen's width is below 960px. I've added a toggle menu button when the screen's width is below 960px. Now you can toggle the `sidenav` even though the screen is small. The function is as below.

![toggle_sidenav](https://user-images.githubusercontent.com/3941889/30282288-c8da891c-974f-11e7-89aa-fb8d056f521f.gif)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))
The issue is mention at #180 .

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've tested this by deploying it on a Rancher backed OpenFaaS environment and opening up the gateway UI. Shrinking and stretching it to see if the toggle menu works correctly. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
