### PR TITLE
Implement Swarm update handler (and use PUT method for updates)

### DIFF
--- a/api-docs/swagger.yml
+++ b/api-docs/swagger.yml
@@ -43,6 +43,23 @@ paths:
       responses:
         '200':
           description: OK
+    put:
+      summary: Update a function.
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Function to update
+          required: true
+          schema:
+            $ref: '#/definitions/CreateFunctionRequest'
+      responses:
+        '200':
+          description: OK
     delete:
       summary: Remove a deployed function.
       description: ''

--- a/gateway/handlers/update_handler.go
+++ b/gateway/handlers/update_handler.go
@@ -1,16 +1,119 @@
 package handlers
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
 	"net/http"
+	"time"
 
 	"github.com/alexellis/faas/gateway/metrics"
+	"github.com/alexellis/faas/gateway/requests"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
 )
 
-// MakeUpdateFunctionHandler request to update an existing function with new configuration such as image, parameters etc.
-func MakeUpdateFunctionHandler(metricsOptions metrics.MetricOptions, c *client.Client, maxRestarts uint64) http.HandlerFunc {
+// MakeUpdateFunctionHandler request to update an existing function with new configuration such as image, envvars etc.
+func MakeUpdateFunctionHandler(metricsOptions metrics.MetricOptions, c *client.Client, maxRestarts uint64, restartDelay time.Duration) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.Background()
+
 		defer r.Body.Close()
-		w.WriteHeader(http.StatusNotImplemented)
+		body, _ := ioutil.ReadAll(r.Body)
+
+		request := requests.CreateFunctionRequest{}
+		err := json.Unmarshal(body, &request)
+		if err != nil {
+			log.Println("Error parsing request:", err)
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		serviceInspectopts := types.ServiceInspectOptions{
+			InsertDefaults: true,
+		}
+
+		service, _, err := c.ServiceInspectWithRaw(ctx, request.Service, serviceInspectopts)
+		if err != nil {
+			log.Println("Error inspecting service", err)
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		updateSpec(&request, &service.Spec, maxRestarts, restartDelay)
+
+		updateOpts := types.ServiceUpdateOptions{}
+		updateOpts.RegistryAuthFrom = types.RegistryAuthFromSpec
+
+		if len(request.RegistryAuth) > 0 {
+			auth, err := BuildEncodedAuthConfig(request.RegistryAuth, request.Image)
+			if err != nil {
+				log.Println("Error building registry auth configuration:", err)
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte("Invalid registry auth"))
+				return
+			}
+			updateOpts.EncodedRegistryAuth = auth
+		}
+
+		response, err := c.ServiceUpdate(ctx, service.ID, service.Version, service.Spec, updateOpts)
+		if err != nil {
+			log.Println("Error updating service:", err)
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("Update error: " + err.Error()))
+			return
+		}
+		log.Println(response.Warnings)
+	}
+}
+
+func updateSpec(request *requests.CreateFunctionRequest, spec *swarm.ServiceSpec, maxRestarts uint64, restartDelay time.Duration) {
+
+	constraints := []string{}
+	if request.Constraints != nil && len(request.Constraints) > 0 {
+		constraints = request.Constraints
+	} else {
+		constraints = linuxOnlyConstraints
+	}
+
+	nets := []swarm.NetworkAttachmentConfig{
+		{Target: request.Network},
+	}
+
+	spec.TaskTemplate.RestartPolicy.MaxAttempts = &maxRestarts
+	spec.TaskTemplate.RestartPolicy.Condition = swarm.RestartPolicyConditionAny
+	spec.TaskTemplate.RestartPolicy.Delay = &restartDelay
+	spec.TaskTemplate.ContainerSpec.Image = request.Image
+	spec.TaskTemplate.ContainerSpec.Labels = map[string]string{
+		"function": "true",
+		"uid":      fmt.Sprintf("%d", time.Now().Nanosecond()),
+	}
+	spec.TaskTemplate.Networks = nets
+	spec.TaskTemplate.Placement = &swarm.Placement{
+		Constraints: constraints,
+	}
+
+	spec.Annotations = swarm.Annotations{
+		Name: request.Service,
+	}
+
+	spec.RollbackConfig = &swarm.UpdateConfig{
+		FailureAction: "pause",
+	}
+
+	spec.UpdateConfig = &swarm.UpdateConfig{
+		Parallelism:   1,
+		FailureAction: "rollback",
+	}
+
+	env := buildEnv(request.EnvProcess, request.EnvVars)
+
+	if len(env) > 0 {
+		spec.TaskTemplate.ContainerSpec.Env = env
 	}
 }


### PR DESCRIPTION
This PR is part of a group of 3:
- openfaas/faas#208
- openfaas/faas-cli#123
- openfaas/faas-provider#4

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR implements an update handler for Docker Swarm, it queries the current spec, updates values in-situ before calling ServiceUpdate.

It also switches to using the PUT verb for updates.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change (#185)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Test Setup
Testing with the following setup:
- Single Docker instance running an insecure registry
- 3 Node Swarm deployed  with `--engine-insecure-registry` for the registry above.

See this [gist](https://gist.github.com/johnmccabe/55baab605c0fb82df9c1cbf8c3dde407) for details on how this was setup (on Windows 10).

Tested using an updated `ruby-echo` function, with the following function yaml.
```
provider:
  name: faas
  gateway: http://10.10.10.198:8080
  network: "func_functions"

  ruby-echo:
    lang: ruby
    handler: ./sample/ruby-echo
    image: 10.10.10.197:5000/ruby-echo
    environment:
      myenvvar: defaultvalue
```

### Manual Test Scenarios
The following manual tests were performed.

- [x] Re-pushed Docker image
- [x] Changed Environment Variable
- [x] Changing constraints
- [x] Number of scaled replicas shouldn't change
- [x] Invalid Docker image

#### Re-pushed Docker image
To test the behaviour when deploying an update where the image tag hasn't changed I carried out the following:
- Updated the ruby-echo function from the faas-cli examples to return a version ID in the echo response 
  ```
  class Handler
      def run(req)
          return "VERSION 1. Input: #{req}"
      end
  end
  ```
- Used faas-cli to build, push and deploy the updated `ruby-echo` function
  `$ faas-cli.exe build -f .\ruby-echo.yml
  `$ faas-cli.exe push -f .\ruby-echo.yml
  `$ faas-cli.exe deploy -f .\ruby-echo.yml
"`
- Invoked the function and confirmed that the response began with `VERSION 1`
- Updated the version in the ruby-echo function (`return "VERSION 2. Input: #{req}"`)
- Used faas-cli to build and update the already deployed ruby-echo function (the image tag has *not* changed)
  `$ faas-cli.exe build -f .\ruby-echo.yml
  `$ faas-cli.exe push -f .\ruby-echo.yml
  `$ faas-cli.exe deploy -f .\ruby-echo.yml --replace=false --update`
- Invoked the function and confirmed that the response began with `VERSION 2`

#### Changed Environment Variable
To test the behaviour when deploying an update where an envvar has been updated:
- Verified the envvar in the deployed `ruby-func` contained the default `myenvvar: defaultvalue` and `fprocess`:
  `$ docker service inspect ruby-echo`
  ```
  "Env": [
      "fprocess=ruby index.rb",
      "mynewenv=defaultvalue"
  ],
  ```
- Updated the ruby-echo.yml to change `myenvvar: defaultvalue` to `myenvvar: updatedvalue`
- Used faas-cli to update the already deployed ruby-echo function
  `faas-cli.exe deploy -f .\ruby-echo.yml --replace=false --update`
- Verified the envvar in the has been updated as expected:
  `$ docker service inspect ruby-echo`
  ```
  "Env": [
      "fprocess=ruby index.rb",
      "mynewenv=updatedvalue"
  ],
  ```

#### Changing constraints
To test the behaviour when deploying an update where the constraints have been updated:
- Checked the current constraints:
  `$ docker service inspect ruby-echo`
  ```
  "Placement": {
      "Constraints": [
          "node.platform.os == linux"
      ]
  },
  ```
- Used faas-cli to update the already deployed ruby-echo function setting a new constraint.
  `faas-cli.exe deploy -f .\ruby-echo.yml --constraint "'node.role == manager" --replace=false --update`
- Verified the constraint in the has been updated as expected. (**NOTE**: when updating constraints the default linux constraint will be overridden so you must explicitly set it):
  `$ docker service inspect ruby-echo`
  ```
  "Placement": {
      "Constraints": [
          "node.role == manager"
      ]
  },
  ```

#### Number of scaled replicas shouldn't change
To test the behaviour when deploying an update to a function which has been scaled, with the Parallelism set to 1 the update takes place incrementally, rather than all at once.
- Checked the current number of replicas:
  `$ docker service inspect ruby-echo`
  ```
  Function                        Invocations     Replicas
  ruby-echo                       2               3
  ```
- Updated the ruby-echo.yml to change the sample envvar to `myenvvar: updatedvaluewhenscaled`
- Used faas-cli to update the already deployed ruby-echo function
  `faas-cli.exe deploy -f .\ruby-echo.yml --replace=false --update`
- Verified the envvar in the has been updated as expected:
  `$ docker service inspect ruby-echo`
  ```
  "Env": [
      "fprocess=ruby index.rb",
      "mynewenv=updatedvaluewhenscaled"
  ],
  ```
- Verified the number of replicas has been maintained:
  `$ docker service inspect ruby-echo`
  ```
  Function                        Invocations     Replicas
  ruby-echo                       2               3
  ```

#### Invalid Docker image
To test the behaviour when deploying an update where the image tag is invalid (ie doesn't exist).

**NOTE** The update will report a success via the API and CLI, with the failure and rollback happening aysnc - @alexellis how does this compare with the K8S implementation, and is it something we want to address here?

- Checked the current image:
  `$ docker service inspect ruby-echo`
  ```
  "Image": "10.10.10.197:5000/ruby-echo",
  ```
- Update `ruby-echo.yml` setting the image to an invalid value `image: 10.10.10.197:5000/ruby-echo-garbage`
- Used faas-cli to attempt to update the already deployed ruby-echo function setting a new invalid image.
  `faas-cli.exe deploy -f .\ruby-echo.yml --replace=false --update`
- Verified the invalid image has been rejected and the function has been rolled back to the working image. 
  `$ docker service inspect ruby-echo`
  ```
  "Image": "10.10.10.197:5000/ruby-echo",
  ```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
