### PR TITLE
Migrate all imports/references to OpenFaaS org

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 ## Motivation and Context
 <!--- Why is this change required? What problem does it solve? -->
 <!--- If it fixes an open issue, please link to the issue here. -->
-- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))
+- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
 
 
 ## How Has This Been Tested?
@@ -26,7 +26,7 @@
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
-- [ ] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
+- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
 - [ ] I have signed-off my commits with `git commit -s`
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ We have a number of areas where we can accept contributions:
 
 **I've found a typo**
 
-* A Pull Request is not necessary. Raise an [Issue](https://github.com/alexellis/faas/issues) and we'll fix it as soon as we can. 
+* A Pull Request is not necessary. Raise an [Issue](https://github.com/openfaas/faas/issues) and we'll fix it as soon as we can. 
 
 **I have a [great] idea**
 
@@ -60,7 +60,7 @@ Maintainers are well-known contributors who help with:
 * Testing and reviewing pull requests
 * Offering other project support and strategical advice
 
-Varying levels of write access are made available via our project bot [Derek](https://github.com/alexellis/derek) to help regular contributors transition to maintainers.
+Varying levels of write access are made available via our project bot [Derek](https://github.com/openfaas/derek) to help regular contributors transition to maintainers.
 
 **Governance**
 
@@ -72,15 +72,15 @@ This project is written in Golang but many of the community contributions so far
 
 #### Community file
 
-The [community.md](https://github.com/alexellis/faas/blob/master/community.md) file highlights blogs, talks and code repos with example FaaS functions and usages. Please send a Pull Request if you are doing something cool with FaaS.
+The [community.md](https://github.com/openfaas/faas/blob/master/community.md) file highlights blogs, talks and code repos with example FaaS functions and usages. Please send a Pull Request if you are doing something cool with FaaS.
 
 #### Roadmap
 
-Checkout the [roadmap](https://github.com/alexellis/faas/blob/master/ROADMAP.md) and [open issues](https://github.com/alexellis/faas/issues).
+Checkout the [roadmap](https://github.com/openfaas/faas/blob/master/ROADMAP.md) and [open issues](https://github.com/openfaas/faas/issues).
 
 #### Slack
 
-There is an Slack community which you are welcome to join to discuss FaaS, IoT and Raspberry Pi projects. Ping [Alex Ellis](https://github.com/alexellis) with your email address so that an invite can be sent out.
+There is an Slack community which you are welcome to join to discuss FaaS, IoT and Raspberry Pi projects. Ping [Alex Ellis](https://github.com/openfaas) with your email address so that an invite can be sent out.
 
 Email: alex@openfaas.com - please send in a one-liner about yourself so we can give you a warm welcome and help you get started.
 

--- a/DEV.md
+++ b/DEV.md
@@ -6,19 +6,19 @@ Before you start development, you may want to take FaaS for a test drive which s
 
 > You can test-drive FaaS with a set of sample functions as defined in docker-compose.yml on play-with-docker.com for free, or on your own laptop.
 
-* [Begin the TestDrive instructions](https://github.com/alexellis/faas/blob/master/TestDrive.md)
+* [Begin the TestDrive instructions](https://github.com/openfaas/faas/blob/master/TestDrive.md)
 
 ### Working on the API Gateway or Watchdog
 
 To work on either of the FaaS Golang components checkout the "./build.sh" scripts and acompanying Dockerfiles.
 
-* [Roadmap and Contributing](https://github.com/alexellis/faas/blob/master/ROADMAP.md)
+* [Roadmap and Contributing](https://github.com/openfaas/faas/blob/master/ROADMAP.md)
 
 ### Creating a function
 
 Functions run as Docker containers with the Watchdog component embedded to handle communication with the API Gateway.
 
-You can find the [reference documentation for the Watchdog here](https://github.com/alexellis/faas/tree/master/watchdog).
+You can find the [reference documentation for the Watchdog here](https://github.com/openfaas/faas/tree/master/watchdog).
 
 
 **Markdown Parser**
@@ -35,7 +35,7 @@ RUN go get github.com/microcosm-cc/bluemonday && \
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-ADD https://github.com/alexellis/faas/releases/download/v0.3-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/v0.3-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 ENV fprocess="/go/src/app/app"
@@ -63,7 +63,7 @@ Update the Docker stack with this:
 ```
 FROM alpine:latest
 
-ADD https://github.com/alexellis/faas/releases/download/v0.3-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/v0.3-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 ENV fprocess="wc"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ OpenFaaS (Functions as a Service) is a framework for building serverless functio
 
 * Ease of use through UI portal and *one-click* install
 * Write functions in any language for Linux or Windows and package in Docker/OCI image format
-* Portable - runs on existing hardware or public/private cloud - [Kubernetes](https://github.com/alexellis/faas-netes) and Docker Swarm native
-* [CLI](http://github.com/alexellis/faas-cli) available with YAML format for templating and defining functions
+* Portable - runs on existing hardware or public/private cloud - [Kubernetes](https://github.com/openfaas/faas-netes) and Docker Swarm native
+* [CLI](http://github.com/openfaas/faas-cli) available with YAML format for templating and defining functions
 * Auto-scales as demand increases
 
 ## Governance
@@ -34,11 +34,11 @@ OpenFaaS is an independent project created by [Alex Ellis](https://www.alexellis
 * Your API Gateway will scale functions according to demand by altering the service replica count in the Docker Swarm or Kubernetes API.
 * A UI is baked in allowing you to invoke functions in your browser and create new ones as needed.
 
-> The API Gateway is a RESTful micro-service and you can view the [Swagger docs here](https://github.com/alexellis/faas/tree/master/api-docs).
+> The API Gateway is a RESTful micro-service and you can view the [Swagger docs here](https://github.com/openfaas/faas/tree/master/api-docs).
 
 ### CLI
 
-Any container or process in a Docker container can be a serverless function in FaaS. Using the [FaaS CLI](http://github.com/alexellis/faas-cli) you can deploy your functions or quickly create new functions from templates such as Node.js or Python.
+Any container or process in a Docker container can be a serverless function in FaaS. Using the [FaaS CLI](http://github.com/openfaas/faas-cli) you can deploy your functions or quickly create new functions from templates such as Node.js or Python.
 
 > The CLI is effectively a RESTful client for the API Gateway.
 
@@ -70,7 +70,7 @@ module.exports = (callback, context) => {
 ```
 *handler.js*
 
-Other [Sample functions](https://github.com/alexellis/faas/tree/master/sample-functions) are available in the Github repository in a range of programming languages.
+Other [Sample functions](https://github.com/openfaas/faas/tree/master/sample-functions) are available in the Github repository in a range of programming languages.
 
 ## Get started with OpenFaaS
 
@@ -78,13 +78,13 @@ Other [Sample functions](https://github.com/alexellis/faas/tree/master/sample-fu
 
 **Docker Swarm**
 
-The deployment guide for Docker Swarm contains a simple one-line command to get you up and running in around 60 seconds. It also includes a set of [sample functions](https://github.com/alexellis/faas/tree/master/sample-functions) which you can use with the TestDrive instructions below.
+The deployment guide for Docker Swarm contains a simple one-line command to get you up and running in around 60 seconds. It also includes a set of [sample functions](https://github.com/openfaas/faas/tree/master/sample-functions) which you can use with the TestDrive instructions below.
 
 [Deployment guide for Docker Swarm](https://github.com/openfaas/faas/blob/master/guide/deployment_swarm.md)
 
 **Kubernetes**
 
-OpenFaaS is Kubernetes-native - you can follow the [deployment guide here](https://github.com/alexellis/faas/blob/master/guide/deployment_k8s.md).
+OpenFaaS is Kubernetes-native - you can follow the [deployment guide here](https://github.com/openfaas/faas/blob/master/guide/deployment_k8s.md).
 
 **Docker Playground**
 
@@ -94,7 +94,7 @@ You can quickly start OpenFaaS on Docker Swarm online using the community-run Do
 
 #### Begin the TestDrive
 
-* [Begin the TestDrive with Docker Swarm](https://github.com/alexellis/faas/blob/master/TestDrive.md)
+* [Begin the TestDrive with Docker Swarm](https://github.com/openfaas/faas/blob/master/TestDrive.md)
 
 Here is a screenshot of the API gateway portal - designed for ease of use.
 
@@ -118,7 +118,7 @@ Functions as a Service or FaaS was a winner in the Cool Hacks contest for Docker
 
 * [Watch my FaaS keynote at Dockercon 2017](https://blog.docker.com/2017/04/dockercon-2017-mobys-cool-hack-sessions/)
 
-If you'd like to find the functions I used in the demos head over to the [faas-dockercon](https://github.com/alexellis/faas-dockercon/) repository.
+If you'd like to find the functions I used in the demos head over to the [faas-dockercon](https://github.com/openfaas/faas-dockercon/) repository.
 
 **Background story**
 
@@ -128,7 +128,7 @@ This is my original blog post on FaaS from January: [Functions as a Service blog
 
 Have you written a blog about OpenFaaS? Send a Pull Request to the community page below.
 
-* [Read blogs/articles and find events about OpenFaaS](https://github.com/alexellis/faas/blob/master/community.md)
+* [Read blogs/articles and find events about OpenFaaS](https://github.com/openfaas/faas/blob/master/community.md)
 
 If you'd like to join OpenFaaS community Slack channel to chat with contributors or get some help - then send a Tweet to [@alexellisuk](https://twitter.com/alexellisuk/) or email alex@openfaas.com.
 
@@ -136,21 +136,21 @@ If you'd like to join OpenFaaS community Slack channel to chat with contributors
 
 OpenFaaS is written in Golang and is MIT licensed - contributions are welcomed whether that means providing feedback, testing existing and new feature or hacking on the source.
 
-To get started you can read the [roadmap](https://github.com/alexellis/faas/blob/master/ROADMAP.md) and [contribution guide](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) or:
+To get started you can read the [roadmap](https://github.com/openfaas/faas/blob/master/ROADMAP.md) and [contribution guide](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) or:
 
-* [Browse FaaS issues on Github](https://github.com/alexellis/faas/issues).
-* [Browse FaaS-CLI issues on Github](https://github.com/alexellis/faas-cli/issues).
+* [Browse FaaS issues on Github](https://github.com/openfaas/faas/issues).
+* [Browse FaaS-CLI issues on Github](https://github.com/openfaas/faas-cli/issues).
 
 Highlights:
 
-* New: Kubernetes support via [FaaS-netes](https://github.com/alexellis/faas-netes) plugin
+* New: Kubernetes support via [FaaS-netes](https://github.com/openfaas/faas-netes) plugin
 * New: FaaS CLI and easy install via `curl` and `brew`
 * New: Windows function support
-* New: Asynchronous/long-running OpenFaaS functions via [NATS Streaming](https://nats.io/documentation/streaming/nats-streaming-intro/) - [Follow this guide](https://github.com/alexellis/faas/blob/master/guide/asynchronous.md)
+* New: Asynchronous/long-running OpenFaaS functions via [NATS Streaming](https://nats.io/documentation/streaming/nats-streaming-intro/) - [Follow this guide](https://github.com/openfaas/faas/blob/master/guide/asynchronous.md)
 
 ### How do I become a contributor?
 
-Anyone is invited to contribute to the project in-line with the [contribution guide](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) - you can also read the guide for ideas on how to get involved. We invite new contributors to join our Slack community. We would also ask you to propose any changes or contributions ahead of time, especially when there is no issue or proposal alredy tracking it.
+Anyone is invited to contribute to the project in-line with the [contribution guide](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) - you can also read the guide for ideas on how to get involved. We invite new contributors to join our Slack community. We would also ask you to propose any changes or contributions ahead of time, especially when there is no issue or proposal alredy tracking it.
 
 ### Other
 
@@ -158,4 +158,4 @@ Example of a Grafana dashboard linked to OpenFaaS showing auto-scaling live in a
 
 ![](https://pbs.twimg.com/media/C9caE6CXUAAX_64.jpg:large)
 
-Sample dashboard JSON file available [here](https://github.com/alexellis/faas/blob/master/contrib/grafana.json)
+Sample dashboard JSON file available [here](https://github.com/openfaas/faas/blob/master/contrib/grafana.json)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,9 +8,9 @@ For an overview of features in August 2017 read the following post:
 
 ## GitHub repos:
 
-* https://github.com/alexellis/faas
-* https://github.com/alexellis/faas-netes
-* https://github.com/alexellis/faas-cli
+* https://github.com/openfaas/faas
+* https://github.com/openfaas/faas-netes
+* https://github.com/openfaas/faas-cli
 * https://github.com/openfaas/nats-queue-worker
 
 ### The API Gateway
@@ -61,7 +61,7 @@ This binary fwatchdog acts as a watchdog for your function. Features:
 
 ## 2. Future items
 
-Most items are detailed [via Github issues](https://github.com/alexellis/faas/issues).
+Most items are detailed [via Github issues](https://github.com/openfaas/faas/issues).
 
 Native support is available for Docker Swarm and Kubernetes using primitive API objects in each orchestration platform.
 
@@ -125,4 +125,4 @@ Internal research is also being done for the ACI / K8s-connector.
 
 ### Contributing
 
-Please see [CONTRIBUTING.md](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md).
+Please see [CONTRIBUTING.md](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md).

--- a/TestDrive.md
+++ b/TestDrive.md
@@ -44,13 +44,13 @@ Some of the sample functions are:
 
 Newly added sample functions (not included in the sample stack)
 
-* Hello world in - [Java/.NET core/Python/Node/Go and more](https://github.com/alexellis/faas/tree/master/sample-functions/BaseFunctions)
-* [Resize images with Image Magick](https://github.com/alexellis/faas/tree/master/sample-functions/ResizeImageMagick)
-* [Function protected by API key in HTTP Header](https://github.com/alexellis/faas/tree/master/sample-functions/ApiKeyProtected)
+* Hello world in - [Java/.NET core/Python/Node/Go and more](https://github.com/openfaas/faas/tree/master/sample-functions/BaseFunctions)
+* [Resize images with Image Magick](https://github.com/openfaas/faas/tree/master/sample-functions/ResizeImageMagick)
+* [Function protected by API key in HTTP Header](https://github.com/openfaas/faas/tree/master/sample-functions/ApiKeyProtected)
 
 ### Invoke the sample functions with curl or Postman:
 
-Head over to the [Github and Star the project](https://github.com/alexellis/faas), or read on to see the input/output from the sample functions.
+Head over to the [Github and Star the project](https://github.com/openfaas/faas), or read on to see the input/output from the sample functions.
 
 ### Working with the sample functions
 
@@ -105,7 +105,7 @@ Guides:
 
 Read the developer guide:
 
-* [Packaging a function](https://github.com/alexellis/faas/blob/master/DEV.md)
+* [Packaging a function](https://github.com/openfaas/faas/blob/master/DEV.md)
 
 The original blog post also walks through creating a function:
 
@@ -115,7 +115,7 @@ The original blog post also walks through creating a function:
 
 **Option 1: via the FaaS CLI**
 
-The FaaS CLI can be used to build functions very quickly though the use of templates. See more details on the FaaS CLI [here](https://github.com/alexellis/faas-cli).
+The FaaS CLI can be used to build functions very quickly though the use of templates. See more details on the FaaS CLI [here](https://github.com/openfaas/faas-cli).
 
 **Option 2: via FaaS UI portal**
 

--- a/api-docs/README.md
+++ b/api-docs/README.md
@@ -6,6 +6,6 @@ The `swagger.yml` file can be viewed and edited in the Swagger UI.
 
 * Now click File -> Import URL
 
-* Type in `https://raw.githubusercontent.com/alexellis/faas/master/api-docs/swagger.yml` and click OK
+* Type in `https://raw.githubusercontent.com/openfaas/faas/master/api-docs/swagger.yml` and click OK
 
 You can now view and edit the Swagger, copy back to your fork before pushing changes.

--- a/api-docs/swagger.yml
+++ b/api-docs/swagger.yml
@@ -194,4 +194,4 @@ definitions:
           ~/.docker/config.json)
 externalDocs:
   description: More documentation available on Github
-  url: 'https://github.com/alexellis/faas'
+  url: 'https://github.com/openfaas/faas'

--- a/community.md
+++ b/community.md
@@ -9,8 +9,8 @@ Welcome to the OpenFaaS community page where you can find:
 There are three main Github repos
 
 * FaaS - the main OpenFaaS repo for the Docker Swarm integration, samples and documentation
-* [FaaS-netes](http://github.com/alexellis/faas-netes) - the Kubernetes back-end for FaaS
-* [FaaS-cli](http://github.com/alexellis/faas-cli) - the user-facing CLI for templating and deploying functions
+* [FaaS-netes](http://github.com/openfaas/faas-netes) - the Kubernetes back-end for FaaS
+* [FaaS-cli](http://github.com/openfaas/faas-cli) - the user-facing CLI for templating and deploying functions
 
 > It would be great to hear from you espcially if you have any of the above and want to share it with the rest of the community. Pull Request or submit a Github Issue.
 
@@ -78,7 +78,7 @@ There are three main Github repos
 ### Third-party integrations / OpenFaaS providers
 | Project name and description                                         | Author     | Site      | Status      |
 |----------------------------------------------------------------------|------------|-----------|-------------|
-| [faas-netes](https://github.com/alexellis/faas-nets) - Kubernetes provider | OpenFaaS | github.com | Supported |
+| [faas-netes](https://github.com/openfaas/faas-nets) - Kubernetes provider | OpenFaaS | github.com | Supported |
 | [faas-nomad](https://github.com/hashicorp/faas-nomad) - Nomad provider | Hashicorp | github.com | Incubation  |
 | [faas-rancher](https://github.com/kenfdev/faas-rancher) - Rancher/Cattle provider | Ken Fukuyama | github.com | Incubation |
 | [faas-hyper](https://github.com/hyperhq/faas-hyper) - Hyper.sh provider | Hyper | github.com | Incubation |
@@ -96,10 +96,10 @@ You can also find cool projects or submit your own to the [faas-and-furious orga
 | [Github - Reverse geocoding](https://github.com/lucj/faas-reverse-geocoding) | Luc Juggery | github.com | 14-September-2017 |
 | [QR Code](https://github.com/faas-and-furious/qrcode) | John McCabe | github.com | 18-August-2017 |
 | [Img2ANSI - GIF/PNG/JPG to ANSI art converter](https://github.com/johnmccabe/faas-img2ansi/) | John McCabe | github.com | 10-August-2017 |
-| [FaaS-netes - Kubernetes backend for FaaS](https://github.com/alexellis/faas-netes) | Alex Ellis | github.com | 25-Jul-2017 |
-| [Twitter, Elastic Search and Alexa stack of functions](https://github.com/alexellis/journey-expert/tree/master/tweetstash) | Alex Ellis | github.com | 24-Apr-2017 |
-| [Dockercon FaaS demos including Alexa/Github](https://github.com/alexellis/faas-dockercon) | Alex Ellis | github.com | 14-Apr-2017 |
-| [Docker Birthday voting app ported to FaaS](https://github.com/alexellis/faas-example-voting-app) | Alex Ellis | github.com | 14-Apr-2017 |
+| [FaaS-netes - Kubernetes backend for FaaS](https://github.com/openfaas/faas-netes) | Alex Ellis | github.com | 25-Jul-2017 |
+| [Twitter, Elastic Search and Alexa stack of functions](https://github.com/openfaas/journey-expert/tree/master/tweetstash) | Alex Ellis | github.com | 24-Apr-2017 |
+| [Dockercon FaaS demos including Alexa/Github](https://github.com/openfaas/faas-dockercon) | Alex Ellis | github.com | 14-Apr-2017 |
+| [Docker Birthday voting app ported to FaaS](https://github.com/openfaas/faas-example-voting-app) | Alex Ellis | github.com | 14-Apr-2017 |
 | [Github-Airtable Bug Tracker integration](https://github.com/aafrey/faas-demo) | Austin Frey | github.com/aafrey/faas-demo | 10-April-2017 |
 | [Github - ascii art generator](https://github.com/developius/faas-node-ascii) | Finnian Anderson | [developius/faas-node-ascii](https://github.com/developius/faas-node-ascii) | 17-April-2017 |
 | [Github - URL Shortener](https://github.com/developius/faas-node-url-shortener) | Finnian Anderson | [developius/faas-node-url-shortener](https://github.com/developius/faas-node-url-shortener) | 19-April-2017 |

--- a/contrib/ci.sh
+++ b/contrib/ci.sh
@@ -10,8 +10,8 @@ echo $GOPATH
 
 
 # Fix-up
-mkdir -p $GOPATH/src/github.com/alexellis/
-cp -r faas $GOPATH/src/github.com/alexellis/
+mkdir -p $GOPATH/src/github.com/openfaas/
+cp -r faas $GOPATH/src/github.com/openfaas/
 
 mkdir -p $GOPATH/src/github.com/openfaas/
 cp -r faas $GOPATH/src/github.com/openfaas/

--- a/contrib/dind/Dockerfile
+++ b/contrib/dind/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker:dind
 WORKDIR /root/
 RUN apk --no-cache add git && \
-  git clone https://github.com/alexellis/faas
+  git clone https://github.com/openfaas/faas
 WORKDIR /root/faas/
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,8 @@ FaaS is a framework for building serverless functions with Docker which has firs
 
 * Ease of use through UI portal and *one-click* install
 * Write functions in any language for Linux or Windows and package in Docker/OCI image format
-* Portable - runs on existing hardware or public/private cloud - [Kubernetes](https://github.com/alexellis/faas-netes) or Docker Swarm
-* [CLI](http://github.com/alexellis/faas-cli) available with YAML format for templating and defining functions
+* Portable - runs on existing hardware or public/private cloud - [Kubernetes](https://github.com/openfaas/faas-netes) or Docker Swarm
+* [CLI](http://github.com/openfaas/faas-cli) available with YAML format for templating and defining functions
 * Auto-scales as demand increases
 
 ## Overview of OpenFaaS
@@ -32,7 +32,7 @@ FaaS is a framework for building serverless functions with Docker which has firs
 
 ### CLI
 
-Any container or process in a Docker container can be a serverless function in FaaS. Using the [FaaS CLI](http://github.com/alexellis/faas-cli) you can deploy your functions or quickly create new functions from templates such as Node.js or Python.
+Any container or process in a Docker container can be a serverless function in FaaS. Using the [FaaS CLI](http://github.com/openfaas/faas-cli) you can deploy your functions or quickly create new functions from templates such as Node.js or Python.
 
 ## Notable mentions
 
@@ -42,7 +42,7 @@ Functions as a Service or FaaS was a winner in the Cool Hacks contest for Docker
 
 * [Watch my FaaS keynote at Dockercon 2017](https://blog.docker.com/2017/04/dockercon-2017-mobys-cool-hack-sessions/)
 
-If you'd like to find the functions I used in the demos head over to the [faas-dockercon](https://github.com/alexellis/faas-dockercon/) repository.
+If you'd like to find the functions I used in the demos head over to the [faas-dockercon](https://github.com/openfaas/faas-dockercon/) repository.
 
 ### InfoWorld
 
@@ -54,7 +54,7 @@ Serdar Yegulalp	Senior Technical Writer covered FaaS in a write-up looking at se
 
 There is also a community being built around FaaS with talks, demos and sample functions being built out.
 
-[Find out about community activity](https://github.com/alexellis/faas/blob/master/community.md)
+[Find out about community activity](https://github.com/openfaas/faas/blob/master/community.md)
 
 ## Getting started
 
@@ -72,14 +72,14 @@ Read up on the background, the top 3 highlighted features and what's coming next
 
 **Test Drive OpenFaaS**
 
-You can [TestDrive](https://github.com/alexellis/faas/blob/master/TestDrive.md) FaaS on your laptop in 60 seconds, or deploy to a free online Docker playground. Find out more in the [TestDrive](https://github.com/alexellis/faas/blob/master/TestDrive.md).
+You can [TestDrive](https://github.com/openfaas/faas/blob/master/TestDrive.md) FaaS on your laptop in 60 seconds, or deploy to a free online Docker playground. Find out more in the [TestDrive](https://github.com/openfaas/faas/blob/master/TestDrive.md).
 
-You can dive straight into the [sample functions here](https://github.com/alexellis/faas/blob/master/sample-functions/README.md). You'll find hello-world examples for the most common programming languages including: Golang, DotNet Core, Java, NodeJS, Python even BusyBox.
+You can dive straight into the [sample functions here](https://github.com/openfaas/faas/blob/master/sample-functions/README.md). You'll find hello-world examples for the most common programming languages including: Golang, DotNet Core, Java, NodeJS, Python even BusyBox.
 
-The [faas-cli](https://github.com/alexellis/faas-cli/) lets you speed up development by creating functions from templates for:
+The [faas-cli](https://github.com/openfaas/faas-cli/) lets you speed up development by creating functions from templates for:
 
-* [Node.js](https://github.com/alexellis/faas-cli/blob/master/test_node.sh)
-* [Python](https://github.com/alexellis/faas-cli/blob/master/test_python.sh)
+* [Node.js](https://github.com/openfaas/faas-cli/blob/master/test_node.sh)
+* [Python](https://github.com/openfaas/faas-cli/blob/master/test_python.sh)
 * Ruby
 * CSharp
 
@@ -93,9 +93,9 @@ FaaS enables you to run your serverless functions in whatever language you like,
 
 Contributions to the project are welcome - please send in issues and questions through Github.
 
-[See issues and PRs](https://github.com/alexellis/faas/issues)
+[See issues and PRs](https://github.com/openfaas/faas/issues)
 
 *What about the name?*
 
-FaaS is becoming OpenFaas, see more here: [Issue 123](https://github.com/alexellis/faas/issues/123)
+FaaS is becoming OpenFaas, see more here: [Issue 123](https://github.com/openfaas/faas/issues/123)
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.7.5 as build
-WORKDIR /go/src/github.com/alexellis/faas/gateway
+WORKDIR /go/src/github.com/openfaas/faas/gateway
 
 COPY vendor         vendor
 
@@ -22,7 +22,7 @@ EXPOSE 8080
 ENV http_proxy      ""
 ENV https_proxy     ""
 
-COPY --from=build /go/src/github.com/alexellis/faas/gateway/gateway    .
+COPY --from=build /go/src/github.com/openfaas/faas/gateway/gateway    .
 
 COPY assets     assets
 

--- a/gateway/Dockerfile.armhf
+++ b/gateway/Dockerfile.armhf
@@ -1,6 +1,6 @@
 FROM alexellis2/go-armhf:1.7.4
 
-WORKDIR /go/src/github.com/alexellis/faas/gateway
+WORKDIR /go/src/github.com/openfaas/faas/gateway
 
 COPY vendor         vendor
 
@@ -21,7 +21,7 @@ EXPOSE 8080
 ENV http_proxy      ""
 ENV https_proxy     ""
 
-COPY --from=0 /go/src/github.com/alexellis/faas/gateway/gateway    .
+COPY --from=0 /go/src/github.com/openfaas/faas/gateway/gateway    .
 
 COPY assets     assets
 

--- a/gateway/build.armhf.sh
+++ b/gateway/build.armhf.sh
@@ -5,7 +5,7 @@ docker build --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_p
     -t functions/gateway:build-armhf . -f Dockerfile.build.armhf
 
 docker create --name gateway_extract functions/gateway:build-armhf echo
-docker cp gateway_extract:/go/src/github.com/alexellis/faas/gateway/app ./gateway
+docker cp gateway_extract:/go/src/github.com/openfaas/faas/gateway/app ./gateway
 docker rm -f gateway_extract
 
 echo Building functions/gateway:latest-armhf-dev

--- a/gateway/handlers/alerthandler.go
+++ b/gateway/handlers/alerthandler.go
@@ -13,7 +13,7 @@ import (
 
 	"fmt"
 
-	"github.com/alexellis/faas/gateway/requests"
+	"github.com/openfaas/faas/gateway/requests"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 )

--- a/gateway/handlers/asyncreport.go
+++ b/gateway/handlers/asyncreport.go
@@ -8,8 +8,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/alexellis/faas/gateway/metrics"
-	"github.com/alexellis/faas/gateway/requests"
+	"github.com/openfaas/faas/gateway/metrics"
+	"github.com/openfaas/faas/gateway/requests"
 )
 
 // MakeAsyncReport makes a handler for asynchronous invocations to report back into.

--- a/gateway/handlers/createhandler.go
+++ b/gateway/handlers/createhandler.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alexellis/faas/gateway/metrics"
-	"github.com/alexellis/faas/gateway/requests"
+	"github.com/openfaas/faas/gateway/metrics"
+	"github.com/openfaas/faas/gateway/requests"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"

--- a/gateway/handlers/deletehandler.go
+++ b/gateway/handlers/deletehandler.go
@@ -12,8 +12,8 @@ import (
 
 	"io/ioutil"
 
-	"github.com/alexellis/faas/gateway/metrics"
-	"github.com/alexellis/faas/gateway/requests"
+	"github.com/openfaas/faas/gateway/metrics"
+	"github.com/openfaas/faas/gateway/requests"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"

--- a/gateway/handlers/forwarding_proxy.go
+++ b/gateway/handlers/forwarding_proxy.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alexellis/faas/gateway/metrics"
-	"github.com/alexellis/faas/gateway/types"
+	"github.com/openfaas/faas/gateway/metrics"
+	"github.com/openfaas/faas/gateway/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/gateway/handlers/proxy.go
+++ b/gateway/handlers/proxy.go
@@ -17,7 +17,7 @@ import (
 	"os"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/alexellis/faas/gateway/metrics"
+	"github.com/openfaas/faas/gateway/metrics"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"

--- a/gateway/handlers/queueproxy.go
+++ b/gateway/handlers/queueproxy.go
@@ -10,8 +10,8 @@ import (
 	"net/url"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/alexellis/faas/gateway/metrics"
-	"github.com/alexellis/faas/gateway/queue"
+	"github.com/openfaas/faas/gateway/metrics"
+	"github.com/openfaas/faas/gateway/queue"
 	"github.com/gorilla/mux"
 )
 

--- a/gateway/handlers/reader.go
+++ b/gateway/handlers/reader.go
@@ -11,8 +11,8 @@ import (
 
 	"strings"
 
-	"github.com/alexellis/faas/gateway/metrics"
-	"github.com/alexellis/faas/gateway/requests"
+	"github.com/openfaas/faas/gateway/metrics"
+	"github.com/openfaas/faas/gateway/requests"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"

--- a/gateway/handlers/update_handler.go
+++ b/gateway/handlers/update_handler.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/alexellis/faas/gateway/metrics"
+	"github.com/openfaas/faas/gateway/metrics"
 	"github.com/docker/docker/client"
 )
 

--- a/gateway/metrics/add_metrics.go
+++ b/gateway/metrics/add_metrics.go
@@ -9,7 +9,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 
-	"github.com/alexellis/faas/gateway/requests"
+	"github.com/openfaas/faas/gateway/requests"
 )
 
 func makeClient() http.Client {

--- a/gateway/metrics/externalwatcher.go
+++ b/gateway/metrics/externalwatcher.go
@@ -13,7 +13,7 @@ import (
 
 	"log"
 
-	"github.com/alexellis/faas/gateway/requests"
+	"github.com/openfaas/faas/gateway/requests"
 )
 
 func AttachExternalWatcher(endpointURL url.URL, metricsOptions MetricOptions, label string, interval time.Duration) {

--- a/gateway/plugin/external.go
+++ b/gateway/plugin/external.go
@@ -16,8 +16,8 @@ import (
 
 	"io/ioutil"
 
-	"github.com/alexellis/faas/gateway/handlers"
-	"github.com/alexellis/faas/gateway/requests"
+	"github.com/openfaas/faas/gateway/handlers"
+	"github.com/openfaas/faas/gateway/requests"
 )
 
 // NewExternalServiceQuery proxies service queries to external plugin via HTTP

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -13,11 +13,11 @@ import (
 	"fmt"
 
 	"github.com/Sirupsen/logrus"
-	natsHandler "github.com/alexellis/faas-nats/handler"
-	internalHandlers "github.com/alexellis/faas/gateway/handlers"
-	"github.com/alexellis/faas/gateway/metrics"
-	"github.com/alexellis/faas/gateway/plugin"
-	"github.com/alexellis/faas/gateway/types"
+	natsHandler "github.com/openfaas/nats-queue-worker/handler"
+	internalHandlers "github.com/openfaas/faas/gateway/handlers"
+	"github.com/openfaas/faas/gateway/metrics"
+	"github.com/openfaas/faas/gateway/plugin"
+	"github.com/openfaas/faas/gateway/types"
 	"github.com/docker/docker/client"
 
 	"github.com/gorilla/mux"

--- a/gateway/tests/alerthandler_test.go
+++ b/gateway/tests/alerthandler_test.go
@@ -6,7 +6,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/alexellis/faas/gateway/handlers"
+	"github.com/openfaas/faas/gateway/handlers"
 )
 
 func TestScale1to5(t *testing.T) {

--- a/gateway/tests/config_test.go
+++ b/gateway/tests/config_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/alexellis/faas/gateway/types"
+	"github.com/openfaas/faas/gateway/types"
 )
 
 type EnvBucket struct {

--- a/gateway/tests/integration/createfunction_test.go
+++ b/gateway/tests/integration/createfunction_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/alexellis/faas/gateway/requests"
+	"github.com/openfaas/faas/gateway/requests"
 )
 
 func createFunction(request requests.CreateFunctionRequest) (string, int, error) {

--- a/gateway/tests/registryauth_test.go
+++ b/gateway/tests/registryauth_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/alexellis/faas/gateway/handlers"
+	"github.com/openfaas/faas/gateway/handlers"
 	"github.com/docker/docker/api/types"
 )
 

--- a/gateway/tests/unmarshall_test.go
+++ b/gateway/tests/unmarshall_test.go
@@ -10,7 +10,7 @@ import (
 
 	"encoding/json"
 
-	"github.com/alexellis/faas/gateway/requests"
+	"github.com/openfaas/faas/gateway/requests"
 )
 
 // TestUnmarshallAlert is an exploratory test from TDD'ing the struct to parse a Prometheus alert

--- a/gateway/vendor/github.com/alexellis/faas-nats/handler/handler.go
+++ b/gateway/vendor/github.com/alexellis/faas-nats/handler/handler.go
@@ -6,7 +6,7 @@ import (
 
 	"encoding/json"
 
-	"github.com/alexellis/faas/gateway/queue"
+	"github.com/openfaas/faas/gateway/queue"
 	"github.com/nats-io/go-nats-streaming"
 )
 

--- a/gateway/vendor/github.com/alexellis/faas-nats/queue-worker/vendor.conf
+++ b/gateway/vendor/github.com/alexellis/faas-nats/queue-worker/vendor.conf
@@ -1,4 +1,4 @@
-github.com/alexellis/faas 4cc299d4c84e7ce10c6a5117e918c5a5b4aeb2ae
+github.com/openfaas/faas 4cc299d4c84e7ce10c6a5117e918c5a5b4aeb2ae
 github.com/nats-io/go-nats-streaming bf8654e90f5296da96eab1e85808eb5c4b7b5541
 github.com/nats-io/go-nats 34c8842105ac0b69c838a9998a239d482936c466
 github.com/nats-io/nuid 3cf34f9fca4e88afa9da8eabd75e3326c9941b44

--- a/guide/asynchronous.md
+++ b/guide/asynchronous.md
@@ -6,7 +6,7 @@ By default functions are accessed synchronously via the following route:
 $ curl --data "message" http://gateway/function/{function_name}
 ```
 
-As of [PR #131](https://github.com/alexellis/faas/pull/131) asynchronous invocation is available for testing.
+As of [PR #131](https://github.com/openfaas/faas/pull/131) asynchronous invocation is available for testing.
 
 *Logical flow for synchronous functions:*
 
@@ -74,4 +74,4 @@ Hard timeout:
 
 To make use of these just add them to your Dockerfile when needed as ENV variables.
 
-> [Function watchdog reference](https://github.com/alexellis/faas/tree/master/watchdog)
+> [Function watchdog reference](https://github.com/openfaas/faas/tree/master/watchdog)

--- a/guide/backends.md
+++ b/guide/backends.md
@@ -13,7 +13,7 @@ There is also community work in-progress to support:
 
 * Rancher/Cattle
 
-The Docker Swarm support is built-into the faas repo, but the Kubernetes support is provided by a microservice in the [faas-netes](https://github.com/alexellis/faas-netes) repo.
+The Docker Swarm support is built-into the faas repo, but the Kubernetes support is provided by a microservice in the [faas-netes](https://github.com/openfaas/faas-netes) repo.
 
 If you're thinking of writing a new back-end we'd love to hear about it and help you, so please get in touch with alex@openfaas.com. Existing implementations (like OpenFaaS) are written in Golang and this provides a level of consistency across the projects.
 
@@ -28,11 +28,11 @@ Here are some ideas:
 * AWS ECS
 * Hyper.sh
 
-If you would like to write your own back-end for `X` then you can write your own microservice that conforms to the [Swagger API](https://github.com/alexellis/faas/tree/master/api-docs) here.
+If you would like to write your own back-end for `X` then you can write your own microservice that conforms to the [Swagger API](https://github.com/openfaas/faas/tree/master/api-docs) here.
 
 ### How does my back-end work?
 
-In order to support a new back end you will write a new "external_provider" and configure this on the API Gateway. The API Gateway will then proxy any requests to your new microservice. The first "external_provider" was the Kubernetes implementation [faas-netes](https://github.com/alexellis/faas-netes):
+In order to support a new back end you will write a new "external_provider" and configure this on the API Gateway. The API Gateway will then proxy any requests to your new microservice. The first "external_provider" was the Kubernetes implementation [faas-netes](https://github.com/openfaas/faas-netes):
 
 ![](https://camo.githubusercontent.com/c250e0dc975e50b6fae3fc84ba5cdc0274bc305c/68747470733a2f2f7062732e7477696d672e636f6d2f6d656469612f44466837692d5a586b41415a6b77342e6a70673a6c61726765)
 
@@ -44,7 +44,7 @@ Invoke your function - through the built-in Swarm or via faas-netes
 
 ![](https://pbs.twimg.com/media/DIyFFnqXgAAMyCh.jpg)
 
-Find out more about the [watchdog here](https://github.com/alexellis/faas/tree/master/watchdog).
+Find out more about the [watchdog here](https://github.com/openfaas/faas/tree/master/watchdog).
 
 ### Automatically compatible OpenFaaS
 
@@ -54,7 +54,7 @@ The following are fully compatible with any additional back-ends:
 * Promethes metrics (tracked through API Gateway)
 * The built-in UI portal (hosted on the API Gateway)
 * The Function Watchdog and any existing OpenFaaS functions
-* The [CLI](https://github.com/alexellis/faas-cli)
+* The [CLI](https://github.com/openfaas/faas-cli)
 * Asynchronous function invocation
 
 Dependent on back-end:
@@ -92,13 +92,13 @@ Method(s): POST
 
 ### Examples / documentation
 
-* See the [Swagger API](https://github.com/alexellis/faas/tree/master/api-docs) as a starting point.
+* See the [Swagger API](https://github.com/openfaas/faas/tree/master/api-docs) as a starting point.
 
 #### faas-netes (Kubernetes)
 
 The Kubernetes integration was written by Alex Ellis and is officially supported by the project.
 
-* See the [FaaS-netes handlers](https://github.com/alexellis/faas-netes/tree/master/handlers) for examples of how to implement each endpoint.
+* See the [FaaS-netes handlers](https://github.com/openfaas/faas-netes/tree/master/handlers) for examples of how to implement each endpoint.
 
 #### Rancher / Cattle (community)
 

--- a/guide/chaining_functions.md
+++ b/guide/chaining_functions.md
@@ -78,4 +78,4 @@ GitHub sends a "star" event to tweetfanclub function, tweetfanclub uses get-avat
 
 This example uses a mix of regular binaries such as ImageMagick and Python handlers generated with the FaaS-CLI.
 
-* [GitHub to Twitter Fanclub](https://github.com/alexellis/faas-twitter-fanclub/blob/master/README.md)
+* [GitHub to Twitter Fanclub](https://github.com/openfaas/faas-twitter-fanclub/blob/master/README.md)

--- a/guide/kong_integration.md
+++ b/guide/kong_integration.md
@@ -8,15 +8,15 @@ Below is a demo of how you could use Kong as an authentication layer for OpenFaa
 
 If you haven't already setup OpenFaaS then you can follow one of the deployment guides available here:
 
-* [Docker Swarm](https://github.com/alexellis/faas/blob/master/guide/deployment_swarm.md)
-* [Kubernetes](https://github.com/alexellis/faas/blob/master/guide/deployment_k8s.md)
+* [Docker Swarm](https://github.com/openfaas/faas/blob/master/guide/deployment_swarm.md)
+* [Kubernetes](https://github.com/openfaas/faas/blob/master/guide/deployment_k8s.md)
 
 Here is a quick reference for Docker Swarm:
 
 ```
 $ docker swarm init --advertise-addr $(hostname -i)
 
-$ git clone https://github.com/alexellis/faas && \
+$ git clone https://github.com/openfaas/faas && \
   cd faas && \
   ./deploy_stack.sh
 ```

--- a/guide/troubleshooting.md
+++ b/guide/troubleshooting.md
@@ -114,7 +114,7 @@ Within the CLI directory for instance:
 Build the samples:
 
 ```
-$ git clone https://github.com/alexellis/faas-cli && \
+$ git clone https://github.com/openfaas/faas-cli && \
   cd faas-cli
 $ faas-cli -action build -f ./samples.yml
 ```

--- a/sample-functions/AlpineFunction/Dockerfile
+++ b/sample-functions/AlpineFunction/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-ADD https://github.com/alexellis/faas/releases/download/0.6.5/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.6.5/fwatchdog /usr/bin
 # COPY ./fwatchdog /usr/bin/
 RUN chmod +x /usr/bin/fwatchdog
 

--- a/sample-functions/AlpineFunction/Dockerfile.armhf
+++ b/sample-functions/AlpineFunction/Dockerfile.armhf
@@ -1,6 +1,6 @@
 FROM arm32v6/alpine:3.6
 
-ADD https://github.com/alexellis/faas/releases/download/0.6.0/fwatchdog-armhf /usr/bin/fwatchdog
+ADD https://github.com/openfaas/faas/releases/download/0.6.0/fwatchdog-armhf /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 # Populate example here

--- a/sample-functions/ApiKeyProtected/Dockerfile
+++ b/sample-functions/ApiKeyProtected/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 8080
 ENV http_proxy      ""
 ENV https_proxy     ""
 
-ADD https://github.com/alexellis/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
 # COPY fwatchdog  /usr/bin/
 RUN chmod +x /usr/bin/fwatchdog
 

--- a/sample-functions/ApiKeyProtected/handler.go
+++ b/sample-functions/ApiKeyProtected/handler.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/alexellis/faas/watchdog/types"
+	"github.com/openfaas/faas/watchdog/types"
 )
 
 func handle(header http.Header, body []byte) {

--- a/sample-functions/BaseFunctions/R/Dockerfile
+++ b/sample-functions/BaseFunctions/R/Dockerfile
@@ -1,6 +1,6 @@
 FROM artemklevtsov/r-alpine:latest
 
-ADD https://github.com/alexellis/faas/releases/download/0.6.1/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.6.1/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 WORKDIR /root/

--- a/sample-functions/BaseFunctions/R/README.Rmd
+++ b/sample-functions/BaseFunctions/R/README.Rmd
@@ -15,7 +15,7 @@ Use this FaaS function using R.
 
 * Option 1 - click *Create a new function* on the FaaS UI
 
-* Option 2 - use the [faas-cli](https://github.com/alexellis/faas-cli/) (experimental)
+* Option 2 - use the [faas-cli](https://github.com/openfaas/faas-cli/) (experimental)
 
 ```
 # curl -sSL https://get.openfaas.com | sudo sh

--- a/sample-functions/BaseFunctions/R/README.md
+++ b/sample-functions/BaseFunctions/R/README.md
@@ -9,7 +9,7 @@ Use this FaaS function using R.
 
 -   Option 1 - click *Create a new function* on the FaaS UI
 
--   Option 2 - use the [faas-cli](https://github.com/alexellis/faas-cli/) (experimental)
+-   Option 2 - use the [faas-cli](https://github.com/openfaas/faas-cli/) (experimental)
 
 <!-- -->
 

--- a/sample-functions/BaseFunctions/cobol/Dockerfile
+++ b/sample-functions/BaseFunctions/cobol/Dockerfile
@@ -1,6 +1,6 @@
 FROM toricls/gnucobol:latest
 
-ADD https://github.com/alexellis/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 WORKDIR /root/

--- a/sample-functions/BaseFunctions/coffee/Dockerfile
+++ b/sample-functions/BaseFunctions/coffee/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:6.9.1-alpine
 
-ADD https://github.com/alexellis/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 WORKDIR /root/

--- a/sample-functions/BaseFunctions/dncore/Dockerfile
+++ b/sample-functions/BaseFunctions/dncore/Dockerfile
@@ -1,6 +1,6 @@
 FROM microsoft/dotnet:sdk
 
-ADD https://github.com/alexellis/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1

--- a/sample-functions/BaseFunctions/golang/Dockerfile
+++ b/sample-functions/BaseFunctions/golang/Dockerfile
@@ -3,12 +3,12 @@ FROM golang:1.7.5-alpine
 MAINTAINER alexellis2@gmail.com
 ENTRYPOINT []
 
-WORKDIR /go/src/github.com/alexellis/faas/sample-functions/golang
-COPY . /go/src/github.com/alexellis/faas/sample-functions/golang
+WORKDIR /go/src/github.com/openfaas/faas/sample-functions/golang
+COPY . /go/src/github.com/openfaas/faas/sample-functions/golang
 
 RUN go install
 
-ADD https://github.com/alexellis/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 ENV fprocess "/go/bin/golang"

--- a/sample-functions/BaseFunctions/golang/Dockerfile.win
+++ b/sample-functions/BaseFunctions/golang/Dockerfile.win
@@ -2,8 +2,8 @@ FROM golang:1.7.5-windowsservercore
 MAINTAINER alexellis2@gmail.com
 ENTRYPOINT []
 
-WORKDIR /go/src/github.com/alexellis/faas/sample-functions/golang
-COPY . /go/src/github.com/alexellis/faas/sample-functions/golang
+WORKDIR /go/src/github.com/openfaas/faas/sample-functions/golang
+COPY . /go/src/github.com/openfaas/faas/sample-functions/golang
 RUN go build
 
 ADD ./watchdog.exe /

--- a/sample-functions/BaseFunctions/golang/README.md
+++ b/sample-functions/BaseFunctions/golang/README.md
@@ -4,7 +4,7 @@ BaseFunction for Golang
 You will find a Dockerfile for Linux and one for Windows so that you can run serverless functions in a mixed-OS swarm.
 
 Dockerfile for Windows
-* [Dockerfile.win](https://github.com/alexellis/faas/blob/master/sample-functions/BaseFunctions/golang/Dockerfile.win)
+* [Dockerfile.win](https://github.com/openfaas/faas/blob/master/sample-functions/BaseFunctions/golang/Dockerfile.win)
 
 This function reads STDIN then prints it back - you can use it to create an "echo service" or as a basis to write your own function.
 

--- a/sample-functions/BaseFunctions/java/Dockerfile
+++ b/sample-functions/BaseFunctions/java/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u121-jdk-alpine
 
-ADD https://github.com/alexellis/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 WORKDIR /root/

--- a/sample-functions/BaseFunctions/node/Dockerfile
+++ b/sample-functions/BaseFunctions/node/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:6.9.1-alpine
 
-ADD https://github.com/alexellis/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 WORKDIR /root/

--- a/sample-functions/BaseFunctions/python/Dockerfile
+++ b/sample-functions/BaseFunctions/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:2.7-alpine
 
-ADD https://github.com/alexellis/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 WORKDIR /root/

--- a/sample-functions/CHelloWorld/src/Dockerfile
+++ b/sample-functions/CHelloWorld/src/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.6 as builder
 RUN apk add --no-cache curl \
-    && curl -SL https://github.com/alexellis/faas/releases/download/0.6.4/fwatchdog > /usr/bin/fwatchdog \
+    && curl -SL https://github.com/openfaas/faas/releases/download/0.6.4/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
     && apk --no-cache del curl
 

--- a/sample-functions/CaptainsIntent/Dockerfile
+++ b/sample-functions/CaptainsIntent/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 RUN apk --update add nodejs nodejs-npm
 
-ADD https://github.com/alexellis/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 COPY package.json   .

--- a/sample-functions/ChangeColorIntent/Dockerfile
+++ b/sample-functions/ChangeColorIntent/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 RUN apk --update add nodejs nodejs-npm
 
-ADD https://github.com/alexellis/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
 #COPY ./fwatchdog /usr/bin/
 RUN chmod +x /usr/bin/fwatchdog
 

--- a/sample-functions/DockerHubStats/Dockerfile
+++ b/sample-functions/DockerHubStats/Dockerfile
@@ -3,12 +3,12 @@ MAINTAINER alexellis2@gmail.com
 ENTRYPOINT []
 
 RUN apk --no-cache add make
-WORKDIR /go/src/github.com/alexellis/faas/sample-functions/DockerHubStats
-COPY . /go/src/github.com/alexellis/faas/sample-functions/DockerHubStats
+WORKDIR /go/src/github.com/openfaas/faas/sample-functions/DockerHubStats
+COPY . /go/src/github.com/openfaas/faas/sample-functions/DockerHubStats
 
 RUN make
 
-ADD https://github.com/alexellis/faas/releases/download/0.6.0/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.6.0/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 ENV fprocess "/go/bin/DockerHubStats"

--- a/sample-functions/DockerHubStats/Dockerfile.armhf
+++ b/sample-functions/DockerHubStats/Dockerfile.armhf
@@ -4,8 +4,8 @@ MAINTAINER alexellis2@gmail.com
 ENTRYPOINT []
 
 RUN apk --no-cache add make
-WORKDIR /go/src/github.com/alexellis/faas/sample-functions/DockerHubStats
-COPY . /go/src/github.com/alexellis/faas/sample-functions/DockerHubStats
+WORKDIR /go/src/github.com/openfaas/faas/sample-functions/DockerHubStats
+COPY . /go/src/github.com/openfaas/faas/sample-functions/DockerHubStats
 
 RUN make
 

--- a/sample-functions/HostnameIntent/Dockerfile
+++ b/sample-functions/HostnameIntent/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 RUN apk --update add nodejs nodejs-npm
 
-ADD https://github.com/alexellis/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 COPY package.json   .

--- a/sample-functions/MarkdownRender/Dockerfile
+++ b/sample-functions/MarkdownRender/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 8080
 ENV http_proxy      ""
 ENV https_proxy     ""
 
-ADD https://github.com/alexellis/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 # COPY fwatchdog  /usr/bin/
 

--- a/sample-functions/MarkdownRender/Dockerfile.armhf
+++ b/sample-functions/MarkdownRender/Dockerfile.armhf
@@ -1,6 +1,6 @@
 FROM arm32v6/alpine:3.6
 
-ADD https://github.com/alexellis/faas/releases/download/0.6.0/fwatchdog-armhf /usr/bin/fwatchdog
+ADD https://github.com/openfaas/faas/releases/download/0.6.0/fwatchdog-armhf /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 WORKDIR /root/

--- a/sample-functions/NodeInfo/Dockerfile
+++ b/sample-functions/NodeInfo/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 RUN apk --update add nodejs nodejs-npm
 
-ADD https://github.com/alexellis/faas/releases/download/0.6.0/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.6.0/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 COPY package.json .

--- a/sample-functions/NodeInfo/Dockerfile.armhf
+++ b/sample-functions/NodeInfo/Dockerfile.armhf
@@ -1,7 +1,7 @@
 FROM arm32v6/alpine:latest
 RUN apk --no-cache add nodejs nodejs-npm
 
-ADD https://github.com/alexellis/faas/releases/download/0.6.0/fwatchdog-armhf /usr/bin/fwatchdog
+ADD https://github.com/openfaas/faas/releases/download/0.6.0/fwatchdog-armhf /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 COPY package.json .

--- a/sample-functions/Phantomjs/Dockerfile
+++ b/sample-functions/Phantomjs/Dockerfile
@@ -1,6 +1,6 @@
 FROM alexellis2/phantomjs-docker:latest
 
-ADD https://github.com/alexellis/faas/releases/download/0.5.6-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.5.6-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 ENV fprocess="phantomjs /dev/stdin"

--- a/sample-functions/Phantomjs/README.md
+++ b/sample-functions/Phantomjs/README.md
@@ -32,7 +32,7 @@ real    0m8.729s
 
 This script visits the front page of CNN and once it is fully loaded - scrapes the title.
 
-See [cnn.js](https://github.com/alexellis/faas/tree/master/sample-functions/Phantomjs/cnn.js) as an example of a Phantomjs script.
+See [cnn.js](https://github.com/openfaas/faas/tree/master/sample-functions/Phantomjs/cnn.js) as an example of a Phantomjs script.
 
-Another example script [feedly_subscribers.js](https://github.com/alexellis/faas/tree/master/sample-functions/Phantomjs/feedly_subscribers.js) gives the count of subscribers for an RSS Feed registered on Feedly.
+Another example script [feedly_subscribers.js](https://github.com/openfaas/faas/tree/master/sample-functions/Phantomjs/feedly_subscribers.js) gives the count of subscribers for an RSS Feed registered on Feedly.
 

--- a/sample-functions/README.md
+++ b/sample-functions/README.md
@@ -2,16 +2,16 @@
 
 For examples of hello-world in different programming languages see inside the BaseFunctions folder:
 
-* [Base Functions](https://github.com/alexellis/faas/tree/master/sample-functions/BaseFunctions)
+* [Base Functions](https://github.com/openfaas/faas/tree/master/sample-functions/BaseFunctions)
 
 ## Demo functions from closing keynote @ Dockercon
 
-* Demo functions - [fass-dockercon](https://github.com/alexellis/faas-dockercon/)
+* Demo functions - [fass-dockercon](https://github.com/openfaas/faas-dockercon/)
 * Video recording from Dockercon [on YouTube](https://youtu.be/-h2VTE9WnZs?t=15m52s)
 
 ## Sample functions from the FaaS stack
 
-> Also see the [community page](https://github.com/alexellis/faas/blob/master/community.md) for functions created by FaaS users and contributors.
+> Also see the [community page](https://github.com/openfaas/faas/blob/master/community.md) for functions created by FaaS users and contributors.
 
 Here is a list of the sample functions included this repository.
 

--- a/sample-functions/ResizeImageMagick/Dockerfile
+++ b/sample-functions/ResizeImageMagick/Dockerfile
@@ -1,6 +1,6 @@
 FROM v4tech/imagemagick
 
-ADD https://github.com/alexellis/faas/releases/download/0.5.2-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.5.2-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 ENV fprocess "convert - -resize 50% fd:1"

--- a/sample-functions/ResizeImageMagick/Dockerfile.armhf
+++ b/sample-functions/ResizeImageMagick/Dockerfile.armhf
@@ -2,7 +2,7 @@ FROM arm32v6/alpine:3.6
 
 RUN apk --no-cache add imagemagick
 
-ADD https://github.com/alexellis/faas/releases/download/0.6.0/fwatchdog-armhf /usr/bin/fwatchdog
+ADD https://github.com/openfaas/faas/releases/download/0.6.0/fwatchdog-armhf /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 ENV fprocess "convert - -resize 50% fd:1"

--- a/sample-functions/ResizeImageMagick/README.md
+++ b/sample-functions/ResizeImageMagick/README.md
@@ -1,6 +1,6 @@
 ## functions/resizer
 
-![](https://github.com/alexellis/faas/blob/master/sample-functions/ResizeImageMagick/gordon.png)
+![](https://github.com/openfaas/faas/blob/master/sample-functions/ResizeImageMagick/gordon.png)
 
 Use this FaaS function to resize an image with ImageMagick.
 
@@ -10,7 +10,7 @@ Use this FaaS function to resize an image with ImageMagick.
 
 * Option 1 - click *Create a new function* on the FaaS UI
 
-* Option 2 - use the [faas-cli](https://github.com/alexellis/faas-cli/) (experimental)
+* Option 2 - use the [faas-cli](https://github.com/openfaas/faas-cli/) (experimental)
 
 ```
 # curl -sSL https://get.openfaas.com | sudo sh

--- a/sample-functions/SentimentAnalysis/Dockerfile
+++ b/sample-functions/SentimentAnalysis/Dockerfile
@@ -3,7 +3,7 @@ FROM python:2.7-alpine
 RUN pip install textblob && \
     python -m textblob.download_corpora
 
-ADD https://github.com/alexellis/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.5.1-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 WORKDIR /root/

--- a/sample-functions/SentimentAnalysis/Dockerfile.armhf
+++ b/sample-functions/SentimentAnalysis/Dockerfile.armhf
@@ -3,7 +3,7 @@ FROM arm32v7/python:2.7-slim
 RUN pip install textblob && \
     python -m textblob.download_corpora
 
-ADD https://github.com/alexellis/faas/releases/download/0.6.0/fwatchdog-armhf /usr/bin/fwatchdog
+ADD https://github.com/openfaas/faas/releases/download/0.6.0/fwatchdog-armhf /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 WORKDIR /root/

--- a/sample-functions/WebhookStash/Dockerfile
+++ b/sample-functions/WebhookStash/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 8080
 ENV http_proxy      ""
 ENV https_proxy     ""
 
-ADD https://github.com/alexellis/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 # COPY fwatchdog  /usr/bin/
 

--- a/sample-functions/catservice/Dockerfile
+++ b/sample-functions/catservice/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 ENTRYPOINT []
 
-ADD https://github.com/alexellis/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 ENV fprocess "/bin/cat"

--- a/sample-functions/gif-maker/Dockerfile
+++ b/sample-functions/gif-maker/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.6
 
 RUN apk --no-cache add ffmpeg gifsicle curl \
-   && curl -LS https://github.com/alexellis/faas/releases/download/0.5.6-alpha/fwatchdog > /usr/bin/fwatchdog \
+   && curl -LS https://github.com/openfaas/faas/releases/download/0.5.6-alpha/fwatchdog > /usr/bin/fwatchdog \
    && chmod +x /usr/bin/fwatchdog \
    && apk del curl
 WORKDIR /root/

--- a/watchdog/Dockerfile
+++ b/watchdog/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.8.3
-RUN mkdir -p /go/src/github.com/alexellis/faas/watchdog
-WORKDIR /go/src/github.com/alexellis/faas/watchdog
+RUN mkdir -p /go/src/github.com/openfaas/faas/watchdog
+WORKDIR /go/src/github.com/openfaas/faas/watchdog
 
 COPY main.go        .
 COPY readconfig.go  .

--- a/watchdog/README.md
+++ b/watchdog/README.md
@@ -17,7 +17,7 @@ The easiest way to create a function is to use a template and the FaaS CLI. The 
 
 * [Your first serverless Python function with OpenFaaS](https://blog.alexellis.io/first-faas-python-function/)
 
-* [Read a tutorial on the FaaS CLI](https://github.com/alexellis/faas-cli)
+* [Read a tutorial on the FaaS CLI](https://github.com/openfaas/faas-cli)
 
 ## Delve deeper
 
@@ -26,7 +26,7 @@ The easiest way to create a function is to use a template and the FaaS CLI. The 
 Here's how to package your function if you don't want to use the CLI or have existing binaries or images:
 
 - [x] Use an existing or a new Docker image as base image `FROM`
-- [x] Add the fwatchdog binary from the [Releases page](https://github.com/alexellis/faas/releases) via `curl` or `ADD https://`
+- [x] Add the fwatchdog binary from the [Releases page](https://github.com/openfaas/faas/releases) via `curl` or `ADD https://`
 - [x] Set an `fprocess` environmental variable with the function you want to run for each request
 - [x] Expose port 8080
 - [x] Set the `CMD` to `fwatchdog`
@@ -36,7 +36,7 @@ Example Dockerfile for an `echo` function:
 ```
 FROM alpine:3.5
 
-ADD https://github.com/alexellis/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/v0.5-alpha/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 # Define your UNIX binary here

--- a/watchdog/build.armhf.sh
+++ b/watchdog/build.armhf.sh
@@ -10,5 +10,5 @@ docker build --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_p
 
 docker create --name buildoutput functions/watchdog:build-armhf echo
 
-docker cp buildoutput:/go/src/github.com/alexellis/faas/watchdog/watchdog ./fwatchdog-armhf
+docker cp buildoutput:/go/src/github.com/openfaas/faas/watchdog/watchdog ./fwatchdog-armhf
 docker rm buildoutput

--- a/watchdog/build.ps1
+++ b/watchdog/build.ps1
@@ -6,5 +6,5 @@ docker build -t alexellis2/watchdog:windows . -f .\Dockerfile.win
 
 docker create --name watchdog alexellis2/watchdog:windows cmd
 
-& docker cp watchdog:/go/src/github.com/alexellis/faas/watchdog/watchdog.exe .
+& docker cp watchdog:/go/src/github.com/openfaas/faas/watchdog/watchdog.exe .
 docker rm -f watchdog

--- a/watchdog/build.sh
+++ b/watchdog/build.sh
@@ -12,10 +12,10 @@ fi
 
 docker create --name buildoutput functions/watchdog:build echo
 
-docker cp buildoutput:/go/src/github.com/alexellis/faas/watchdog/watchdog ./fwatchdog
-docker cp buildoutput:/go/src/github.com/alexellis/faas/watchdog/watchdog-armhf ./fwatchdog-armhf
-docker cp buildoutput:/go/src/github.com/alexellis/faas/watchdog/watchdog-arm64 ./fwatchdog-arm64
-docker cp buildoutput:/go/src/github.com/alexellis/faas/watchdog/watchdog.exe ./fwatchdog.exe
+docker cp buildoutput:/go/src/github.com/openfaas/faas/watchdog/watchdog ./fwatchdog
+docker cp buildoutput:/go/src/github.com/openfaas/faas/watchdog/watchdog-armhf ./fwatchdog-armhf
+docker cp buildoutput:/go/src/github.com/openfaas/faas/watchdog/watchdog-arm64 ./fwatchdog-arm64
+docker cp buildoutput:/go/src/github.com/openfaas/faas/watchdog/watchdog.exe ./fwatchdog.exe
 
 docker rm buildoutput
 

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alexellis/faas/watchdog/types"
+	"github.com/openfaas/faas/watchdog/types"
 )
 
 func buildFunctionInput(config *WatchdogConfig, r *http.Request) ([]byte, error) {


### PR DESCRIPTION
## Description
This commit updates all imports and references in documentation/scripts to point at the new github OpenFaaS org.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change (#123)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
