### PR TITLE
Fixes #245 Added os.TempDir() to replace using '/tmp/'

### DIFF
--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	"path/filepath"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -252,13 +253,11 @@ func main() {
 
 	http.HandleFunc("/", makeRequestHandler(&config))
 
-	if config.suppressLock == false {
-		path := "/tmp/.lock"
-		log.Printf("Writing lock-file to: %s\n", path)
-		writeErr := ioutil.WriteFile(path, []byte{}, 0660)
-		if writeErr != nil {
-			log.Panicf("Cannot write %s. To disable lock-file set env suppress_lock=true.\n Error: %s.\n", path, writeErr.Error())
-		}
+	path := filepath.Join(os.TempDir(), ".lock")
+	log.Printf("Writing lock-file to: %s\n", path)
+	writeErr := ioutil.WriteFile(path, []byte{}, 0660)
+	if writeErr != nil {
+		log.Panicf("Cannot write %s. To disable lock-file set env suppress_lock=true.\n Error: %s.\n", path, writeErr.Error())
 	}
 	log.Fatal(s.ListenAndServe())
 }


### PR DESCRIPTION
## Description
This PR fixes issue #245 of the lock file not being crossplatform because of just using '/tmp/'. os.TempDir() is used to find a temporary dir, completely crossplatform. ~~Because of this, suppressLock is no longer needed and has been removed.~~

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] @alexellis has raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I built the code, ~~removed the tests for supressLock and the parts of suppressLock in the config since it's not needed,~~ also tested the `filepath.Join(os.TempDir(), ".lock")` code on a Windows and Linux computer, and the actual fwatchdog file on Windows and Linux.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) (sorta)?
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. (unsure about this)
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes. (unsure)
- [ ] All new and existing tests passed.

I'm fairly new to collaborating and commiting to projects so please LMK if I did anything wrong. I don't believe new tests are needed as well but am unsure, as well as with docs.
