### PR TITLE
Clean up a confusing point in TestDrive.md

### DIFF
--- a/TestDrive.md
+++ b/TestDrive.md
@@ -29,9 +29,9 @@ This one-shot script clones the code, initialises Docker swarm mode and then dep
 
 > If you are not testing on play-with-docker then remove `--advertise-addr eth0` from first line of the script.
 
-* Now that everything's deployed take note of the two DNS entries at the top of the screen.
+* Now that everything's deployed take note of the two DNS entries at the top of the screen (the round links '9090' and '8080' highlighted in the screenshot below).
 
-![](https://pbs.twimg.com/media/C1wDi_tXUAIphu-.jpg)
+[![C1w_Di_t_XUAIphu-.jpg](https://s25.postimg.org/xiohxgz6n/C1w_Di_t_XUAIphu-.jpg)](https://postimg.org/image/n8m2y89az/)
 
 ## Sample functions
 


### PR DESCRIPTION
I honestly had a lot of trouble figuring out the edited line in the TestDrive documentation.  I added some more explanation and edited the screenshot to make it more obvious for beginners.

## Description
See summary.

## Motivation and Context
For the life of me I couldn't figure out what was meant by 'two DNS entries at the top of the screen'.  Had to go find a youtube video to realize that the ports were links that could be clicked to access the instance.
- [ ] I didn't raise an issue for this, I just wrote the doc change and opened this PR as the issue notification.


## How Has This Been Tested?
I edited the screenshot, posted it to http://postimages.org/ and viewed it on github.com in my fork and it looked fine.