### PR TITLE
Fixes #235 - Add docker push to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,9 @@ script:
     - sh build.sh
     # Invoke ci script too
     - sh contrib/ci.sh
+after_success:
+    - if [ ! -s "$TRAVIS_TAG" ] ; then 
+        docker tag $DOCKER_USERNAME/gateway:latest-dev $DOCKER_USERNAME/gateway:$TRAVIS_TAG;
+        docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD;
+        docker push $DOCKER_USERNAME/gateway:$TRAVIS_TAG;
+        fi


### PR DESCRIPTION
Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

## Description
Added push to Docker Hub on git tag with image tagging

Must set the Travis-CI environment variables on the project:
DOCKER_USERNAME and DOCKER_PASSWORD
in order to log in to docker for the push. Make sure the setting 'Display value in build log' is disabled
This will run when a git tag is pushed into the repository. It will push one image with the git tag value

## Motivation and Context
Hacktoberfest!


## How Has This Been Tested?
`git tag -a 1.0 -m "Tagging the commit"`
`git push origin 1.0`
then watch Travis do the work!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
