### PR TITLE
change to use 3.3 spec to allow attachable network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.2"
+version: "3.3"
 services:
     gateway:
         volumes:
@@ -201,5 +201,4 @@ services:
 networks:
     functions:
         driver: overlay
-        # Docker does not support this option yet - maybe create outside of the stack and reference as "external"?
-        #attachable: true
+        attachable: true


### PR DESCRIPTION
Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>

## Description
We would like the network running on Docker Swarm attachable.
Actually `docker-compose.yml` v3.3 is supported by Docker 17.06.2+.
This fix is trivial.

## How Has This Been Tested?
  0. `./deploy_stack.sh` it should deploy the stack without error.
  0. `docker inspect func_functions` it should show that this network is attachable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This change allows use to attach other services to the current stack.
This change will make 17.06.2 the minimum version of Docker required by OpenFaaS.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
