### PR TITLE
Remove '--name' in faas-cli invoke

### DIFF
--- a/TestDrive.md
+++ b/TestDrive.md
@@ -84,7 +84,7 @@ You can access the sample functions via the command line with a HTTP POST reques
 * Invoke the markdown function with the CLI:
 
 ```
-$ echo "# Test *Drive*"| faas-cli invoke --name func_markdown
+$ echo "# Test *Drive*"| faas-cli invoke func_markdown
 <h1>Test <em>Drive</em></h1>
 ```
 

--- a/guide/chaining_functions.md
+++ b/guide/chaining_functions.md
@@ -18,8 +18,8 @@ $ curl -d "# test" localhost:8080/function/markdown | \
 You could also do this via code, or through the `faas-cli`:
 
 ```
-$ echo "test" | faas-cli invoke --name markdown | \
-faas-cli invoke --name slack
+$ echo "test" | faas-cli invoke markdown | \
+faas-cli invoke slack
 ```
 
 ## Server-side access via gateway

--- a/guide/deployment_k8s.md
+++ b/guide/deployment_k8s.md
@@ -89,8 +89,8 @@ Your function will appear after a few seconds and you can click "Invoke"
 You can also use the CLI like this:
 
 ```
-$ echo -n "" | faas-cli invoke --gateway http://kubernetes-ip:31112 --name nodeinfo
-$ echo -n "verbose" | faas-cli invoke --gateway http://kubernetes-ip:31112 --name nodeinfo
+$ echo -n "" | faas-cli invoke --gateway http://kubernetes-ip:31112 nodeinfo
+$ echo -n "verbose" | faas-cli invoke --gateway http://kubernetes-ip:31112 nodeinfo
 ```
 
 ## Asynchronous functions


### PR DESCRIPTION
## Description
Remove '--name' in faas-cli invoke

## Motivation and Context
Doc can not execute. '--name' is removed.

see:https://github.com/openfaas/faas-cli/commit/e0973014146164fbefae3bbd34d644e921b2ae98#diff-6e522d40e6848a6eeeb12b0ab50cb97d

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
