### PR TITLE
Forward path and query string through proxy

### DIFF
--- a/gateway/requests/forward_request.go
+++ b/gateway/requests/forward_request.go
@@ -1,0 +1,29 @@
+package requests
+
+import "fmt"
+import "net/url"
+
+// ForwardRequest for proxying incoming requests
+type ForwardRequest struct {
+	RawPath  string
+	RawQuery string
+	Method   string
+}
+
+// NewForwardRequest create a ForwardRequest
+func NewForwardRequest(method string, url url.URL) ForwardRequest {
+	return ForwardRequest{
+		Method:   method,
+		RawQuery: url.RawQuery,
+		RawPath:  url.Path,
+	}
+}
+
+// ToURL create formatted URL
+func (f *ForwardRequest) ToURL(addr string, watchdogPort int) string {
+	if len(f.RawQuery) > 0 {
+		return fmt.Sprintf("http://%s:%d%s?%s", addr, watchdogPort, f.RawPath, f.RawQuery)
+	}
+	return fmt.Sprintf("http://%s:%d%s", addr, watchdogPort, f.RawPath)
+
+}

--- a/gateway/tests/forward_request_test.go
+++ b/gateway/tests/forward_request_test.go
@@ -1,0 +1,75 @@
+package tests
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/openfaas/faas/gateway/requests"
+)
+
+func TestFormattingOfURLWithPath_NoQuery(t *testing.T) {
+	req := requests.ForwardRequest{
+		RawQuery: "",
+		RawPath:  "/encode/utf8/",
+		Method:   http.MethodPost,
+	}
+
+	url := req.ToURL("markdown", 8080)
+	want := "http://markdown:8080/encode/utf8/"
+	if url != want {
+		t.Logf("Got: %s, want: %s", url, want)
+		t.Fail()
+	}
+}
+
+func TestFormattingOfURLAtRoot_NoQuery(t *testing.T) {
+	req := requests.ForwardRequest{
+		RawQuery: "",
+		RawPath:  "/",
+		Method:   http.MethodPost,
+	}
+
+	url := req.ToURL("markdown", 8080)
+	want := "http://markdown:8080/"
+	if url != want {
+		t.Logf("Got: %s, want: %s", url, want)
+		t.Fail()
+	}
+}
+
+// experimental test
+// func TestMyURL(t *testing.T) {
+// 	v, _ := url.Parse("http://markdown/site?query=test")
+// 	t.Logf("RequestURI %s", v.RequestURI())
+// 	t.Logf("extra %s", v.Path)
+// }
+
+func TestUrlForFlask(t *testing.T) {
+	req := requests.ForwardRequest{
+		RawQuery: "query=uptime",
+		RawPath:  "/function/flask",
+		Method:   http.MethodPost,
+	}
+
+	url := req.ToURL("flask", 8080)
+	want := "http://flask:8080/function/flask?query=uptime"
+	if url != want {
+		t.Logf("Got: %s, want: %s", url, want)
+		t.Fail()
+	}
+}
+
+func TestFormattingOfURL_OneQuery(t *testing.T) {
+	req := requests.ForwardRequest{
+		RawQuery: "name=alex",
+		RawPath:  "/",
+		Method:   http.MethodPost,
+	}
+
+	url := req.ToURL("flask", 8080)
+	want := "http://flask:8080/?name=alex"
+	if url != want {
+		t.Logf("Got: %s, want: %s", url, want)
+		t.Fail()
+	}
+}

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -201,10 +201,20 @@ func getAdditionalEnvs(config *WatchdogConfig, r *http.Request, method string) [
 
 		envs = append(envs, fmt.Sprintf("Http_Method=%s", method))
 
-		log.Println(r.URL.String())
-		if len(r.URL.String()) > 0 {
-			envs = append(envs, fmt.Sprintf("Http_Query=%s", r.URL.String()))
+		if config.writeDebug {
+			log.Println("Query ", r.URL.RawQuery)
 		}
+		if len(r.URL.RawQuery) > 0 {
+			envs = append(envs, fmt.Sprintf("Http_Query=%s", r.URL.RawQuery))
+		}
+
+		if config.writeDebug {
+			log.Println("Path ", r.URL.Path)
+		}
+		if len(r.URL.Path) > 0 {
+			envs = append(envs, fmt.Sprintf("Http_Path=%s", r.URL.Path))
+		}
+
 	}
 
 	return envs


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Forward path and query string all the way through proxy to the watchdog and forked process

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Brings work forward out of WIP PR:

#174 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

A good way to test is to build a new watchdog and gateway, then deploy functions/alpine with the fprocess as `env` - then try adding different query URLs or query strings along with the proxy request.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
