### PR TITLE
Simplified UI development instructions in HACK.md

### DIFF
--- a/contrib/HACK.md
+++ b/contrib/HACK.md
@@ -1,19 +1,33 @@
 ## Build a development API Gateway
 
-Create `functions/gateway:latest-dev`
+Create `functions/gateway:latest-dev`:
 
 ```
 $ cd gateway/
 $ ./build.sh
 ```
 
-Now edit the gateway service in your `docker-compose.yml` file and deploy the stack.
+If you want to use a different tag rather than `latest-dev` then pass in the tag to `build.sh` for example:
 
-If you want to use an overridden name then pass in the tag to the `./build.sh` script such as `./build.sh test-1`.
+```
+$ ./build.sh test-1
+```
 
-## Hack on the UI for the API Gateway
+Now edit the `docker-compose.yml` file and replace `services.gateway.image` with:
 
-To hack on the UI without rebuilding the gateway mount the assets in a bind-mount like this:
+```
+image: functions/gateway:latest-dev
+```
+
+Now deploy the stack with:
+
+```
+$ ./deploy_stack.sh
+```
+
+## Gateway UI development
+
+When making changes to the gateway UI, continuously rebuilding the gateway and redeploying the stack can be tedious and time consuming. The instructions below allow development on the UI without rebuilding/redeploying by mounting the assets directory in a bind-mount.
 
 Remove the Docker stack, then create the faas network as "attachable":
 
@@ -22,7 +36,23 @@ $ docker stack rm func
 $ docker network create func_functions --driver=overlay --attachable=true
 ```
 
-Now edit the `docker-compose.yml` file and replace the existing networks block with:
+Now edit the `docker-compose.yml` file:
+
+1) Replace `services.gateway.volumes` with:
+
+```
+volumes:
+    - "/var/run/docker.sock:/var/run/docker.sock"
+    - "./gateway/assets:/root/assets"
+```
+
+2) Replace `services.gateway.image` with:
+
+```
+image: functions/gateway:latest-dev
+```
+
+3) Replace `networks` with:
 
 ```
 networks:
@@ -31,11 +61,8 @@ networks:
             name: func_functions
 ```
 
-Now you can run the gateway as its own container and bind-mount in the HTML assets.
+Now deploy the stack with:
 
 ```
-$ docker run -v `pwd`/gateway/assets:/root/assets -v "/var/run/docker.sock:/var/run/docker.sock" \
--p 8080:8080 --network=func_functions -d functions/gateway:latest-dev
+$ ./deploy_stack.sh
 ```
-
-Now deploy the rest of the stack with: `./deploy_stack.sh`.


### PR DESCRIPTION
When following the instructions in HACK.md, without removing the gateway service a develper could mistakenly end up with two gateway services in their docker stack. To avoid this confusion and simplify the process of doing UI changes i've updated the document.

This is a documentation change only.