### PR TITLE
251 debug write default false

### DIFF
--- a/watchdog/README.md
+++ b/watchdog/README.md
@@ -79,6 +79,7 @@ The watchdog can be configured through environmental variables. You must always 
 | `read_timeout`         | HTTP timeout for reading the payload from the client caller (in seconds) |
 | `suppress_lock`        | The watchdog will attempt to write a lockfile to /tmp/ for swarm healthchecks - set this to true to disable behaviour. |
 | `exec_timeout`         | Hard timeout for process exec'd for each incoming request (in seconds). Disabled if set to 0. |
+| `write_debug`          | Write all output, error messages, and additional information to the logs. Default is false. |
  
 
 ## Advanced / tuning

--- a/watchdog/config_test.go
+++ b/watchdog/config_test.go
@@ -51,32 +51,19 @@ func TestRead_CgiHeaders_DefaultIsTrueConfig(t *testing.T) {
 	}
 }
 
-func TestRead_WriteDebug_DefaultIsTrueConfig(t *testing.T) {
+func TestRead_WriteDebug_DefaultIsFalseConfig(t *testing.T) {
 	defaults := NewEnvBucket()
 	readConfig := ReadConfig{}
-
-	config := readConfig.Read(defaults)
-
-	if config.writeDebug != true {
-		t.Logf("writeDebug should have been true (unspecified)")
-		t.Fail()
-	}
-}
-
-func TestRead_WriteDebug_FalseOverrideConfig(t *testing.T) {
-	defaults := NewEnvBucket()
-	readConfig := ReadConfig{}
-	defaults.Setenv("write_debug", "false")
 
 	config := readConfig.Read(defaults)
 
 	if config.writeDebug != false {
-		t.Logf("writeDebug should have been false (specified)")
+		t.Logf("writeDebug should have been false (unspecified)")
 		t.Fail()
 	}
 }
 
-func TestRead_WriteDebug_TrueConfig(t *testing.T) {
+func TestRead_WriteDebug_TrueOverrideConfig(t *testing.T) {
 	defaults := NewEnvBucket()
 	readConfig := ReadConfig{}
 	defaults.Setenv("write_debug", "true")
@@ -85,6 +72,19 @@ func TestRead_WriteDebug_TrueConfig(t *testing.T) {
 
 	if config.writeDebug != true {
 		t.Logf("writeDebug should have been true (specified)")
+		t.Fail()
+	}
+}
+
+func TestRead_WriteDebug_FlaseConfig(t *testing.T) {
+	defaults := NewEnvBucket()
+	readConfig := ReadConfig{}
+	defaults.Setenv("write_debug", "false")
+
+	config := readConfig.Read(defaults)
+
+	if config.writeDebug != false {
+		t.Logf("writeDebug should have been false (specified)")
 		t.Fail()
 	}
 }

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -145,8 +145,6 @@ func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request,
 		if config.writeDebug == true {
 			log.Printf("Success=%t, Error=%s\n", targetCmd.ProcessState.Success(), err.Error())
 			log.Printf("Out=%s\n", out)
-		} else {
-			log.Printf("An Error Occurred\n")
 		}
 
 		if ri.headerWritten == false {

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -145,6 +145,8 @@ func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request,
 		if config.writeDebug == true {
 			log.Printf("Success=%t, Error=%s\n", targetCmd.ProcessState.Success(), err.Error())
 			log.Printf("Out=%s\n", out)
+		} else {
+			log.Printf("An Error Occurred\n")
 		}
 
 		if ri.headerWritten == false {
@@ -162,6 +164,8 @@ func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request,
 
 	if config.writeDebug == true {
 		os.Stdout.Write(out)
+	} else {
+		log.Printf("Wrote %d Bytes\n", len(out))
 	}
 
 	if len(config.contentType) > 0 {

--- a/watchdog/readconfig.go
+++ b/watchdog/readconfig.go
@@ -43,7 +43,7 @@ func parseIntValue(val string) int {
 // Read fetches config from environmental variables.
 func (ReadConfig) Read(hasEnv HasEnv) WatchdogConfig {
 	cfg := WatchdogConfig{
-		writeDebug: true,
+		writeDebug: false,
 		cgiHeaders: true,
 	}
 


### PR DESCRIPTION
Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Made write_debug false by default. Added log message to show amount of bytes written (to show it worked)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes https://github.com/openfaas/faas/issues/251

## How Has This Been Tested?
Ran the markdown function with several lines of text (as described in the ticket). Verified the output was unchanged, but the logs now only show "Wrote 48 Bytes". Before, the logs would have every line of the output.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
