### PR TITLE
Add start, stop, and status commands to deploy scripts

### DIFF
--- a/deploy_extended.sh
+++ b/deploy_extended.sh
@@ -5,5 +5,32 @@ if ! [ -x "$(command -v docker)" ]; then
   exit 1
 fi
 
-echo "Deploying extended stack"
-docker stack deploy func --compose-file docker-compose.extended.yml
+if [ $# -eq 0 ]; then
+  command="start"
+else
+  command="$1"
+fi
+
+case "$command" in
+  start)
+    echo "Deploying extended stack"
+    docker stack deploy func --compose-file docker-compose.extended.yml
+    ;;
+  stop)
+    echo "Stopping stack"
+    docker stack rm func
+    ;;
+  status)
+    docker stack ps func
+    ;;
+  help)
+    echo "Available commands:"
+    echo "start  - start the stack"
+    echo "stop   - stop the stack"
+    echo "status - stack status"
+    ;;
+  *)
+    echo "$0: Invalid command: $command"
+    exit 1
+    ;;
+esac

--- a/deploy_stack.armhf.sh
+++ b/deploy_stack.armhf.sh
@@ -5,5 +5,32 @@ if ! [ -x "$(command -v docker)" ]; then
   exit 1
 fi
 
-echo "Deploying stack"
-docker stack deploy func --compose-file docker-compose.armhf.yml
+if [ $# -eq 0 ]; then
+  command="start"
+else
+  command="$1"
+fi
+
+case "$command" in
+  start)
+    echo "Deploying stack"
+    docker stack deploy func --compose-file docker-compose.armhf.yml
+    ;;
+  stop)
+    echo "Stopping stack"
+    docker stack rm func
+    ;;
+  status)
+    docker stack ps func
+    ;;
+  help)
+    echo "Available commands:"
+    echo "start  - start the stack"
+    echo "stop   - stop the stack"
+    echo "status - stack status"
+    ;;
+  *)
+    echo "$0: Invalid command: $command"
+    exit 1
+    ;;
+esac

--- a/deploy_stack.sh
+++ b/deploy_stack.sh
@@ -5,6 +5,32 @@ if ! [ -x "$(command -v docker)" ]; then
   exit 1
 fi
 
-echo "Deploying stack"
-docker stack deploy func --compose-file docker-compose.yml
+if [ $# -eq 0 ]; then
+  command="start"
+else
+  command="$1"
+fi
 
+case "$command" in
+  start)
+    echo "Deploying stack"
+    docker stack deploy func --compose-file docker-compose.yml
+    ;;
+  stop)
+    echo "Stopping stack"
+    docker stack rm func
+    ;;
+  status)
+    docker stack ps func
+    ;;
+  help)
+    echo "Available commands:"
+    echo "start  - start the stack"
+    echo "stop   - stop the stack"
+    echo "status - stack status"
+    ;;
+  *)
+    echo "$0: Invalid command: $command"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Signed-off-by: Mark Peek <markpeek@vmware.com>

## Description
This change adds start, stop, and status commands to the deploy_*.sh scripts.

## Motivation and Context
Improve the ease of use for new users with an easy way to both start and stop the stack.

## How Has This Been Tested?
Manual testing of the scripts except for the armhf script.