### PR TITLE
Added optional body to function calls

### DIFF
--- a/api-docs/swagger.yml
+++ b/api-docs/swagger.yml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   description: FaaS API documentation
-  version: 0.6.1
+  version: 0.6.5
   title: FaaS API Gateway
   license:
     name: MIT
@@ -145,38 +145,56 @@ paths:
           description: Alert handled successfully
         '500':
           description: Internal error with swarm or request JSON invalid
-  /async-function/{functionName}:
+  '/async-function/{functionName}':
     post:
-      summary: 'Invoke a function asynchronously in OpenFaaS'
+      summary: Invoke a function asynchronously in OpenFaaS
       parameters:
         - in: path
           name: functionName
           description: Function name
           type: string
           required: true
+        - in: body
+          name: input
+          description: (Optional) data to pass to function
+          schema:
+            type: string
+            format: binary
+            example:
+              '{"hello": "world"}'
+          required: false
       responses:
         '202':
           description: Request accepted and queued
-        '500':
-          description: Internal server or queue error
         '404':
           description: Requested function not found
-  /function/{functionName}:
+        '500':
+          description: Internal server error
+  '/function/{functionName}':
     post:
-      summary: 'Invoke a function defined in OpenFaaS'
+      summary: Invoke a function defined in OpenFaaS
       parameters:
         - in: path
           name: functionName
           description: Function name
           type: string
           required: true
+        - in: body
+          name: input
+          description: (Optional) data to pass to function
+          schema:
+            type: string
+            format: binary
+            example:
+              '{"hello": "world"}'
+          required: false
       responses:
         '200':
           description: Value returned from function
-        '500':
-          description: Error connecting to function
         '404':
           description: Function not found
+        '500':
+          description: Error connecting to function
 definitions:
   DeleteFunctionRequest:
     type: object


### PR DESCRIPTION
The optional body parameter to be passed to STDIN wasn't part of the previous swagger spec.

## Description

The title really says it all. I loaded the http://editor.swagger.io/ editor and couldn't see the body parameter, so I've added it as an optional parameter. It looks like the editor re-organised the response codes to numeric order, so I've left the changes in, in-case anyone else wants to verify or generate code using http://editor.swagger.io/

## Motivation and Context

- [x] ~~I have raised~~ an issue to propose this change (exists compliments #214)


## How Has This Been Tested?

This is more like documentation than code, but follows https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md and http://editor.swagger.io/
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
