### PR TITLE
[WIP] Enable GET method for functions

### DIFF
--- a/gateway/handlers/proxy.go
+++ b/gateway/handlers/proxy.go
@@ -141,7 +141,7 @@ func invokeService(w http.ResponseWriter, r *http.Request, metrics metrics.Metri
 	contentType := r.Header.Get("Content-Type")
 	fmt.Printf("[%s] Forwarding request [%s] to: %s\n", stamp, contentType, url)
 
-	request, err := http.NewRequest("POST", url, bytes.NewReader(requestBody))
+	request, err := http.NewRequest(r.Method, url, bytes.NewReader(requestBody))
 
 	copyHeaders(&request.Header, &r.Header)
 

--- a/gateway/handlers/proxy.go
+++ b/gateway/handlers/proxy.go
@@ -45,12 +45,13 @@ func MakeProxy(metrics metrics.MetricOptions, wildcard bool, client *client.Clie
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
-		if r.Method == "POST" {
+		switch r.Method {
+		case "POST", "GET":
 			logger.Infoln(r.Header)
 
-			xfunctionHeader := r.Header["X-Function"]
-			if len(xfunctionHeader) > 0 {
-				logger.Infoln(xfunctionHeader)
+			xFunctionHeader := r.Header["X-Function"]
+			if len(xFunctionHeader) > 0 {
+				logger.Infoln(xFunctionHeader)
 			}
 
 			// getServiceName
@@ -59,8 +60,8 @@ func MakeProxy(metrics metrics.MetricOptions, wildcard bool, client *client.Clie
 				vars := mux.Vars(r)
 				name := vars["name"]
 				serviceName = name
-			} else if len(xfunctionHeader) > 0 {
-				serviceName = xfunctionHeader[0]
+			} else if len(xFunctionHeader) > 0 {
+				serviceName = xFunctionHeader[0]
 			}
 
 			if len(serviceName) > 0 {
@@ -69,8 +70,8 @@ func MakeProxy(metrics metrics.MetricOptions, wildcard bool, client *client.Clie
 				w.WriteHeader(http.StatusBadRequest)
 				w.Write([]byte("Provide an x-function header or valid route /function/function_name."))
 			}
-
-		} else {
+			break
+		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
 	}

--- a/watchdog/Makefile
+++ b/watchdog/Makefile
@@ -1,0 +1,2 @@
+linux: 
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w" -installsuffix cgo -o fwatchdog

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -25,8 +25,14 @@ func buildFunctionInput(config *WatchdogConfig, r *http.Request) ([]byte, error)
 	var requestBytes []byte
 	var err error
 
-	if r.Body != nil {
-		defer r.Body.Close()
+	if r.Body == nil {
+		return res, nil
+	}
+	defer r.Body.Close()
+
+	if err != nil {
+		log.Println(err)
+		return res, err
 	}
 
 	requestBytes, err = ioutil.ReadAll(r.Body)
@@ -37,6 +43,7 @@ func buildFunctionInput(config *WatchdogConfig, r *http.Request) ([]byte, error)
 	} else {
 		res = requestBytes
 	}
+
 	return res, err
 }
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Enable GET method for functions. This is work in-progress and may need review - i.e. to allow functions to opt out of this method whether it causes them to block or wait for input.

Todo:
* [ ] Certify incubator tests https://github.com/openfaas/certify-incubator
* [ ] Opt-out mechanism
* [ ] Support mechanism for definition via environment or labels re: #178 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

User request for "GET" support. Also asked for by @JockDaRock for Flask/Express support.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in a web-browser and on the command-line, also benefits from fixes in #318

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Additional testing and tyre-kicking appreciated. 