### PR TITLE
Add spinner during function invoke in the web ui

### DIFF
--- a/gateway/assets/index.html
+++ b/gateway/assets/index.html
@@ -115,10 +115,11 @@
                             </span>
                             <div layout-gt-sm="row">
                                 <md-input-container class="md-block" flex-gt-sm>
-                                    <button ng-click="fireRequest()" class="md-raised md-button md-ink-ripple" type="button">
+                                    <button ng-click="fireRequest()" class="md-raised md-button md-ink-ripple" type="button" ng-disabled="invocationInProgress">
                                         <span class="ng-scope">Invoke</span><div class="md-ripple-container"></div>
                                     </button>
                                 </md-input-container>
+                                <md-progress-circular md-mode="indeterminate" ng-show="invocationInProgress"></md-progress-circular>
                             </div>
 
                             <div layout-gt-sm="row">

--- a/gateway/assets/script/bootstrap.js
+++ b/gateway/assets/script/bootstrap.js
@@ -7,6 +7,7 @@ var app = angular.module('faasGateway', ['ngMaterial']);
 app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$mdDialog', '$mdToast', '$mdSidenav',
         function($scope, $log, $http, $location, $timeout, $mdDialog, $mdToast, $mdSidenav) {
     $scope.functions = [];
+    $scope.invocationInProgress = false;
     $scope.invocationRequest = "";
     $scope.invocationResponse = "";
     $scope.invocationStatus = "";
@@ -41,7 +42,6 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
     };
 
     $scope.fireRequest = function() {
-
         var options = {
             url: "/function/" + $scope.selectedFunction.name,
             data: $scope.invocation.request,
@@ -49,6 +49,7 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
             headers: { "Content-Type": $scope.invocation.contentType == "json" ? "application/json" : "text/plain" },
             responseType: $scope.invocation.contentType
         };
+        $scope.invocationInProgress = true;
         $scope.invocationResponse = "";
         $scope.invocationStatus = null;
 
@@ -59,9 +60,11 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
                 } else {
                     $scope.invocationResponse = response.data;
                 }
+                $scope.invocationInProgress = false;
                 $scope.invocationStatus = response.status;
                 showPostInvokedToast("Success");
             }).catch(function(error1) {
+                $scope.invocationInProgress = false;
                 $scope.invocationResponse = error1.statusText + "\n" + error1.data;
                 $scope.invocationStatus = error1.status;
 
@@ -105,6 +108,7 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
             $scope.invocation.request = "";
             $scope.invocationResponse = "";
             $scope.invocationStatus = "";
+            $scope.invocationInProgress = false;
             $scope.invocation.contentType = "text";
         }
     };


### PR DESCRIPTION
## Description
- Add a simple sinner when the function is invoked
- Disable the invoke button until the request returns

## Motivation and Context
This change provides better user experience and feedback while waiting for function invocation to finish.  This specifically address #328 

- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested manually in the browser, see the gif attached below

![preview of change](https://media.giphy.com/media/3o7aD2qKQ34JUVyYSY/giphy.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
