### PR TITLE
[gateway] pass request body to service without buffering;

### DIFF
--- a/gateway/handlers/proxy.go
+++ b/gateway/handlers/proxy.go
@@ -93,8 +93,7 @@ func lookupInvoke(w http.ResponseWriter, r *http.Request, metrics metrics.Metric
 		defer trackTime(time.Now(), metrics, name)
 		forwardReq := requests.NewForwardRequest(r.Method, *r.URL)
 
-		requestBody, _ := ioutil.ReadAll(r.Body)
-		invokeService(w, r, metrics, name, forwardReq, requestBody, logger, proxyClient)
+		invokeService(w, r, metrics, name, forwardReq, logger, proxyClient)
 	}
 }
 
@@ -107,7 +106,7 @@ func lookupSwarmService(serviceName string, c *client.Client) (bool, error) {
 	return len(services) > 0, err
 }
 
-func invokeService(w http.ResponseWriter, r *http.Request, metrics metrics.MetricOptions, service string, forwardReq requests.ForwardRequest, requestBody []byte, logger *logrus.Logger, proxyClient *http.Client) {
+func invokeService(w http.ResponseWriter, r *http.Request, metrics metrics.MetricOptions, service string, forwardReq requests.ForwardRequest, logger *logrus.Logger, proxyClient *http.Client) {
 	stamp := strconv.FormatInt(time.Now().Unix(), 10)
 
 	defer func(when time.Time) {
@@ -140,7 +139,7 @@ func invokeService(w http.ResponseWriter, r *http.Request, metrics metrics.Metri
 	contentType := r.Header.Get("Content-Type")
 	fmt.Printf("[%s] Forwarding request [%s] to: %s\n", stamp, contentType, url)
 
-	request, err := http.NewRequest("POST", url, bytes.NewReader(requestBody))
+	request, _ := http.NewRequest("POST", url, r.Body)
 
 	copyHeaders(&request.Header, &r.Header)
 


### PR DESCRIPTION
## Description

This change removes an unecessary ioutil.ReadAll() from gateway/handlers/proxy.go.
The incoming request is already passed to the invokeService() function, so the requests body is used directly to construct the service request.

This helps fixing #337 but additional work needs to be done on other layers;

## Motivation and Context

This is needed to process input data which is bigger than the available memory of the worker.
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
I ran the test suite and everything is ok. This change is just an implementation detail.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
