### PR TITLE
[WIP] Add support for multipart/form-data to Watchdog

### DIFF
--- a/watchdog/types/types.go
+++ b/watchdog/types/types.go
@@ -27,6 +27,17 @@ type MarshalReq struct {
 	Body   MarshalBody `json:"body"`
 }
 
+type FormPart struct {
+	Value    string `json:"value"`
+	Filename string `json:"filename,omitempty"`
+	Encoded  bool   `json:"encoded"`
+}
+
+type Form struct {
+	Header http.Header         `json:"header"`
+	Form   map[string]FormPart `json:"form"`
+}
+
 func UnmarshalRequest(data []byte) (*MarshalReq, error) {
 	request := MarshalReq{}
 	err := json.Unmarshal(data, &request)
@@ -42,5 +53,21 @@ func MarshalRequest(data []byte, header *http.Header) ([]byte, error) {
 	}
 
 	res, marshalErr := json.Marshal(&req)
+	return res, marshalErr
+}
+
+func UnmarshalForm(data []byte) (*Form, error) {
+	form := new(Form)
+	err := json.Unmarshal(data, form)
+	return form, err
+}
+
+func MarshalForm(data map[string]FormPart, header *http.Header) ([]byte, error) {
+	form := Form{
+		Form:   data,
+		Header: *header,
+	}
+
+	res, marshalErr := json.Marshal(&form)
 	return res, marshalErr
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR is being raised for visibility and should be considered a proof-of-concept at this point - it adds basic support for `multipart/form-data` to the Watchdog.

Forms submitted to the Watchdog are sent to the function in a JSON object keyed on the part name, with binary data base64 encoded with a flag indicating that its encoded along with the part filename if present.

The JSON object sent to the function is a `types.Form` struct and includes the headers received in addition to the Form data.

This should remain backwards compatible with existing behaviour, its only triggered when the requests mediaType indicates that its `multipart/form-data`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change (#344)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Have created a visual diff function that uses multipart/form-data submission to pass multiple files to the function.

    faas-cli deploy --image=johnmccabe/imgdiff --name=imgdiff --fprocess="/usr/bin/imgdiff"

This can be invoked using curl as follows (where `original.png` and `altered.png` are in the local dir):

    curl localhost:8080/function/imgdiff -F "reference=@original.png" -F "new=@altered.png" > out.png

Will make the source of this function available asap.

Will update with tests/docs etc if it is something @alexellis would like included. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
