### PR TITLE
[WIP] Return 500 if GET /system/functions fails

### DIFF
--- a/gateway/handlers/reader.go
+++ b/gateway/handlers/reader.go
@@ -6,20 +6,20 @@ package handlers
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"log"
 	"net/http"
 
 	"strings"
 
-	"github.com/openfaas/faas/gateway/metrics"
-	"github.com/openfaas/faas/gateway/requests"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
+	"github.com/openfaas/faas/gateway/metrics"
+	"github.com/openfaas/faas/gateway/requests"
 )
 
 // MakeFunctionReader gives a summary of Function structs with Docker service stats overlaid with Prometheus counters.
-func MakeFunctionReader(metricsOptions metrics.MetricOptions, c *client.Client) http.HandlerFunc {
+func MakeFunctionReader(metricsOptions metrics.MetricOptions, c client.ServiceAPIClient) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		serviceFilter := filters.NewArgs()
@@ -30,11 +30,14 @@ func MakeFunctionReader(metricsOptions metrics.MetricOptions, c *client.Client) 
 
 		services, err := c.ServiceList(context.Background(), options)
 		if err != nil {
-			fmt.Println(err)
+			log.Println("Error getting service list:", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("Error getting service list"))
+			return
 		}
 
 		// TODO: Filter only "faas" functions (via metadata?)
-		var functions []requests.Function
+		functions := []requests.Function{}
 
 		for _, service := range services {
 

--- a/gateway/tests/reader_test.go
+++ b/gateway/tests/reader_test.go
@@ -1,0 +1,208 @@
+package tests
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/openfaas/faas/gateway/handlers"
+	"github.com/openfaas/faas/gateway/metrics"
+	"github.com/openfaas/faas/gateway/requests"
+	"golang.org/x/net/context"
+)
+
+type testServiceApiClient struct {
+	serviceListServices []swarm.Service
+	serviceListError    error
+}
+
+func (c testServiceApiClient) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options types.ServiceCreateOptions) (types.ServiceCreateResponse, error) {
+	return types.ServiceCreateResponse{}, nil
+}
+
+func (c testServiceApiClient) ServiceInspectWithRaw(ctx context.Context, serviceID string, options types.ServiceInspectOptions) (swarm.Service, []byte, error) {
+	return swarm.Service{}, []byte{}, nil
+}
+
+func (c testServiceApiClient) ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
+	return c.serviceListServices, c.serviceListError
+}
+
+func (c testServiceApiClient) ServiceRemove(ctx context.Context, serviceID string) error {
+	return nil
+}
+
+func (c testServiceApiClient) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (types.ServiceUpdateResponse, error) {
+	return types.ServiceUpdateResponse{}, nil
+}
+
+func (c testServiceApiClient) ServiceLogs(ctx context.Context, serviceID string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (c testServiceApiClient) TaskLogs(ctx context.Context, taskID string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (c testServiceApiClient) TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error) {
+	return swarm.Task{}, []byte{}, nil
+}
+
+func (c testServiceApiClient) TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error) {
+	return []swarm.Task{}, nil
+}
+
+func TestReaderSuccessReturnsOK(t *testing.T) {
+	m := metrics.MetricOptions{}
+	c := &testServiceApiClient{
+		serviceListServices: []swarm.Service{},
+		serviceListError:    nil,
+	}
+	handler := handlers.MakeFunctionReader(m, c)
+
+	w := httptest.NewRecorder()
+	r := &http.Request{}
+	handler.ServeHTTP(w, r)
+
+	expected := http.StatusOK
+	if status := w.Code; status != expected {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, expected)
+	}
+}
+
+func TestReaderSuccessReturnsJsonContent(t *testing.T) {
+	m := metrics.MetricOptions{}
+	c := &testServiceApiClient{
+		serviceListServices: []swarm.Service{},
+		serviceListError:    nil,
+	}
+	handler := handlers.MakeFunctionReader(m, c)
+
+	w := httptest.NewRecorder()
+	r := &http.Request{}
+	handler.ServeHTTP(w, r)
+
+	expected := "application/json"
+	if contentType := w.Header().Get("Content-Type"); contentType != expected {
+		t.Errorf("content type header does not match: got %v want %v",
+			contentType, expected)
+	}
+}
+
+func TestReaderSuccessReturnsCorrectBodyWithZeroFunctions(t *testing.T) {
+	m := metrics.MetricOptions{}
+	c := &testServiceApiClient{
+		serviceListServices: []swarm.Service{},
+		serviceListError:    nil,
+	}
+	handler := handlers.MakeFunctionReader(m, c)
+
+	w := httptest.NewRecorder()
+	r := &http.Request{}
+	handler.ServeHTTP(w, r)
+
+	expected := "[]"
+	if w.Body.String() != expected {
+		t.Errorf("handler returned wrong body: got %v want %v",
+			w.Body.String(), expected)
+	}
+}
+
+func TestReaderSuccessReturnsCorrectBodyWithOneFunction(t *testing.T) {
+	replicas := uint64(5)
+	services := []swarm.Service{
+		swarm.Service{
+			Spec: swarm.ServiceSpec{
+				Mode: swarm.ServiceMode{
+					Replicated: &swarm.ReplicatedService{
+						Replicas: &replicas,
+					},
+				},
+				Annotations: swarm.Annotations{
+					Name: "bar",
+				},
+				TaskTemplate: swarm.TaskSpec{
+					ContainerSpec: swarm.ContainerSpec{
+						Env: []string{
+							"fprocess=bar",
+						},
+						Image: "foo/bar:latest",
+						Labels: map[string]string{
+							"function": "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+	m := metrics.MetricOptions{}
+	c := &testServiceApiClient{
+		serviceListServices: services,
+		serviceListError:    nil,
+	}
+	handler := handlers.MakeFunctionReader(m, c)
+
+	w := httptest.NewRecorder()
+	r := &http.Request{}
+	handler.ServeHTTP(w, r)
+
+	functions := []requests.Function{
+		requests.Function{
+			Name:            "bar",
+			Image:           "foo/bar:latest",
+			InvocationCount: 0,
+			Replicas:        5,
+			EnvProcess:      "bar",
+		},
+	}
+	marshalled, _ := json.Marshal(functions)
+	expected := string(marshalled)
+	if w.Body.String() != expected {
+		t.Errorf("handler returned wrong body: got %v want %v",
+			w.Body.String(), expected)
+	}
+}
+
+func TestReaderErrorReturnsInternalServerError(t *testing.T) {
+	m := metrics.MetricOptions{}
+	c := &testServiceApiClient{
+		serviceListServices: nil,
+		serviceListError:    errors.New("error"),
+	}
+	handler := handlers.MakeFunctionReader(m, c)
+
+	w := httptest.NewRecorder()
+	r := &http.Request{}
+	handler.ServeHTTP(w, r)
+
+	expected := http.StatusInternalServerError
+	if status := w.Code; status != expected {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, expected)
+	}
+}
+
+func TestReaderErrorReturnsCorrectBody(t *testing.T) {
+	m := metrics.MetricOptions{}
+	c := &testServiceApiClient{
+		serviceListServices: nil,
+		serviceListError:    errors.New("error"),
+	}
+	handler := handlers.MakeFunctionReader(m, c)
+
+	w := httptest.NewRecorder()
+	r := &http.Request{}
+	handler.ServeHTTP(w, r)
+
+	expected := "Error getting service list"
+	if w.Body.String() != expected {
+		t.Errorf("handler returned wrong body: got %v want %v",
+			w.Body.String(), expected)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Alex Young <alex@heuris.io>

This is the beginning of the work on creating a more RESTful API (#214). It can be considered for merging on it's own however if there is work already happening to address this issue.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- If the call to ServiceList fails in the reader, 500 is returned with an error message. Before this change the handler returned 200 with the string `null`.
- If there are no functions then an empty array is returned. Before this change, the string `null` was returned

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Running unit tests in `reader_test.go`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
