### PR TITLE
Add Http_ContentLength for deterministic functions

### DIFF
--- a/watchdog/README.md
+++ b/watchdog/README.md
@@ -91,7 +91,8 @@ Headers and other request information are injected into environmental variables 
 The `X-Forwarded-By` header becomes available as `Http_X_Forwarded_By`
 
 * `Http_Method` - GET/POST etc
-* `Http_Query` - Querystring value
+* `Http_Query` - QueryString value
+* `Http_ContentLength` - gives the total content-length of the incoming HTTP request received by the watchdog.
 
 > This behaviour is enabled by the `cgi_headers` environmental variable which is enabled by default.
 

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -202,6 +202,7 @@ func getAdditionalEnvs(config *WatchdogConfig, r *http.Request, method string) [
 		}
 
 		envs = append(envs, fmt.Sprintf("Http_Method=%s", method))
+		envs = append(envs, fmt.Sprintf("Http_ContentLength=%d", r.ContentLength))
 
 		if config.writeDebug {
 			log.Println("Query ", r.URL.RawQuery)


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add Http_ContentLength for deterministic functions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Enables deterministic reading from stdin. cc/ @Lewiscowles1986 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With unit tests and the `env` built-in shell command.

Set process to `env` and pass a body of `test`

```
...
Http_ContentLength=4
...
```

See README.md for updates

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.