### PR TITLE
Suggestion - basic auth security with Nginx

### DIFF
--- a/contrib/nginx/.gitignore
+++ b/contrib/nginx/.gitignore
@@ -1,0 +1,1 @@
+openfaas.htpasswd

--- a/contrib/nginx/Dockerfile
+++ b/contrib/nginx/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:latest
+
+COPY gateway.conf /etc/nginx/conf.d/default.conf
+

--- a/contrib/nginx/README.md
+++ b/contrib/nginx/README.md
@@ -33,14 +33,37 @@ ID                          NAME                DRIVER              CREATED     
 q70h0nsj9odbtv12vrsijcutx   openfaas_htpasswd                       13 seconds ago      13 seconds ago
 ```
 
-### Launch nginx
+### Remove the exposed port on the gateway
+
+```
+$ docker service update func_gateway --publish-rm 8080
+```
+
+### Build an Nginx container
 
 Build gwnginx from contrib directory. 
 
 ```
+$ docker build -t gwnginx .
+```
+
+### Launch nginx
+
+Deploy Nginx
+
+```
 $ docker service rm gwnginx ; \
  docker service create --network=func_functions \
-   --secret openfaas_htpasswd --publish 8081:8080 --name gwnginx gwnginx 
+   --secret openfaas_htpasswd \
+   --publish 8080:8080 --name gwnginx gwnginx 
 ```
+
+### Connect to the UI
+
+You can now connect to the UI on port 8080. If you use a web-browser you will be prompted for a password.
+
+**API/CLI**
+
+The API will require Basic Auth but can stil be used with `curl`. We have work under testing to support basic auth inside the `faas-cli` natively.
 
 

--- a/contrib/nginx/README.md
+++ b/contrib/nginx/README.md
@@ -1,0 +1,46 @@
+### Create a .htaccess:
+
+```
+$ sudo apt-get install apache2-utils
+```
+
+```
+$ htpasswd -c openfaas.htpasswd admin
+New password: 
+Re-type new password: 
+Adding password for user admin
+```
+
+Example:
+
+```
+$ cat openfaas.htpasswd 
+admin:$apr1$BgwAfB5i$dfzQPXy6VliPCVqofyHsT.
+```
+
+### Create a secret in the cluster
+
+```
+$ docker secret create --label openfaas openfaas_htpasswd openfaas.htpasswd 
+q70h0nsj9odbtv12vrsijcutx
+```
+
+You can now see the secret created:
+
+```
+$ docker secret ls
+ID                          NAME                DRIVER              CREATED             UPDATED
+q70h0nsj9odbtv12vrsijcutx   openfaas_htpasswd                       13 seconds ago      13 seconds ago
+```
+
+### Launch nginx
+
+Build gwnginx from contrib directory. 
+
+```
+$ docker service rm gwnginx ; \
+ docker service create --network=func_functions \
+   --secret openfaas_htpasswd --publish 8081:8080 --name gwnginx gwnginx 
+```
+
+

--- a/contrib/nginx/README.md
+++ b/contrib/nginx/README.md
@@ -1,3 +1,18 @@
+### Basic auth in 5 seconds
+
+This guide shows you how to protect your cluster with "Basic Auth" which involves setting a username
+and password. This method will prevent tampering but for production usage will also need TLS
+enabling. Free TLS certificates can be generated with LetsEncrypt.
+
+Steps:
+
+* Generate a password file
+* Push file into secret store
+* Unexpose the gateway
+* Create an Nginx proxy container with the new secret
+
+* Test it out.
+
 ### Create a .htaccess:
 
 ```
@@ -39,12 +54,12 @@ q70h0nsj9odbtv12vrsijcutx   openfaas_htpasswd                       13 seconds a
 $ docker service update func_gateway --publish-rm 8080
 ```
 
-### Build an Nginx container
+### Build an Nginx container (optional)
 
-Build gwnginx from contrib directory. 
+Build gwnginx from contrib directory if you need customizations.
 
 ```
-$ docker build -t gwnginx .
+$ docker build -t alexellis/gwnginx:0.1 .
 ```
 
 ### Launch nginx

--- a/contrib/nginx/gateway.conf
+++ b/contrib/nginx/gateway.conf
@@ -1,0 +1,42 @@
+ server {
+  listen       8080;
+
+#  location ~ ^/(/system|/ui)/ {
+
+   location /system {
+      proxy_set_header    X-Real-IP $remote_addr;
+      proxy_set_header    Host      $http_host;
+      proxy_pass          http://gateway:8080/;
+      auth_basic "Restricted";                    		#For Basic Auth
+      auth_basic_user_file /var/run/secrets/openfaas.htpasswd;  #For Basic Auth
+  }
+ 
+  location / {
+      proxy_set_header    X-Real-IP $remote_addr;
+      proxy_set_header    Host      $http_host;
+      proxy_pass          http://gateway:8080/;
+  }
+ 
+  location /ui {
+      proxy_set_header    X-Real-IP $remote_addr;
+      proxy_set_header    Host      $http_host;
+      proxy_pass          http://gateway:8080/;
+      auth_basic "Restricted";                    		#For Basic Auth
+      auth_basic_user_file /var/run/secrets/openfaas.htpasswd;  #For Basic Auth
+  }
+  
+  location /async/function {
+	proxy_set_header    X-Real-IP $remote_addr;
+        proxy_set_header    Host      $http_host;
+        proxy_pass          http://gateway:8080/;
+  }
+
+
+  location /function {
+	proxy_set_header    X-Real-IP $remote_addr;
+        proxy_set_header    Host      $http_host;
+        proxy_pass          http://gateway:8080/;
+  }
+
+}
+

--- a/contrib/nginx/gateway.conf
+++ b/contrib/nginx/gateway.conf
@@ -1,7 +1,18 @@
  server {
   listen       8080;
 
-
+  location /async-function/ {
+      proxy_set_header    X-Real-IP $remote_addr;
+      proxy_set_header    Host      $http_host;
+      proxy_pass          http://gateway:8080/async-function/;
+  }
+ 
+  location /function/ {
+      proxy_set_header    X-Real-IP $remote_addr;
+      proxy_set_header    Host      $http_host;
+      proxy_pass          http://gateway:8080/function/;
+  }
+ 
   location / {
       proxy_set_header    X-Real-IP $remote_addr;
       proxy_set_header    Host      $http_host;

--- a/contrib/nginx/gateway.conf
+++ b/contrib/nginx/gateway.conf
@@ -1,42 +1,14 @@
  server {
   listen       8080;
 
-#  location ~ ^/(/system|/ui)/ {
 
-   location /system {
-      proxy_set_header    X-Real-IP $remote_addr;
-      proxy_set_header    Host      $http_host;
-      proxy_pass          http://gateway:8080/;
-      auth_basic "Restricted";                    		#For Basic Auth
-      auth_basic_user_file /var/run/secrets/openfaas.htpasswd;  #For Basic Auth
-  }
- 
   location / {
       proxy_set_header    X-Real-IP $remote_addr;
       proxy_set_header    Host      $http_host;
       proxy_pass          http://gateway:8080/;
+       auth_basic "Restricted";                    		#For Basic Auth
+      auth_basic_user_file /var/run/secrets/openfaas_htpasswd;  #For Basic Auth
   }
  
-  location /ui {
-      proxy_set_header    X-Real-IP $remote_addr;
-      proxy_set_header    Host      $http_host;
-      proxy_pass          http://gateway:8080/;
-      auth_basic "Restricted";                    		#For Basic Auth
-      auth_basic_user_file /var/run/secrets/openfaas.htpasswd;  #For Basic Auth
-  }
-  
-  location /async/function {
-	proxy_set_header    X-Real-IP $remote_addr;
-        proxy_set_header    Host      $http_host;
-        proxy_pass          http://gateway:8080/;
-  }
-
-
-  location /function {
-	proxy_set_header    X-Real-IP $remote_addr;
-        proxy_set_header    Host      $http_host;
-        proxy_pass          http://gateway:8080/;
-  }
-
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Minimal example for validation / testing to setup basic auth with Nginx for the whole gateway.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Context - #349

This requires some manual steps which means it won't be possible to do a `docker stack deploy` and get going. Here's the workflow:

* Create .htpassword using CLI
* Create Docker secret using CLI
* Deploy stack

The main change is that the gateway would not be exposed, but Nginx would be instead. 