### PR TITLE
Return correct Content-Type from an AddMetricsHandler wrapped handler

### DIFF
--- a/gateway/metrics/add_metrics.go
+++ b/gateway/metrics/add_metrics.go
@@ -12,16 +12,8 @@ import (
 	"github.com/openfaas/faas/gateway/requests"
 )
 
-func makeClient() http.Client {
-	// Fine-tune the client to fail fast.
-	return http.Client{}
-}
-
 // AddMetricsHandler wraps a http.HandlerFunc with Prometheus metrics
-func AddMetricsHandler(handler http.HandlerFunc, host string, port int) http.HandlerFunc {
-	client := makeClient()
-
-	prometheusQuery := NewPrometheusQuery(host, port, &client)
+func AddMetricsHandler(handler http.HandlerFunc, fetchQuery FetchQuery) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// log.Printf("Calling upstream for function info\n")
 
@@ -55,10 +47,13 @@ func AddMetricsHandler(handler http.HandlerFunc, host string, port int) http.Han
 		// log.Printf("Querying Prometheus API\n")
 		// `sum(gateway_function_invocation_total{function_name=~".*", code=~".*"}) by (function_name, code)`)
 		expr := "sum(gateway_function_invocation_total%7Bfunction_name%3D~%22.*%22%2C+code%3D~%22.*%22%7D)+by+(function_name%2C+code)"
-		results, fetchErr := prometheusQuery.Fetch(expr)
+		results, fetchErr := fetchQuery.Fetch(expr)
 		if fetchErr != nil {
 			log.Printf("Error querying Prometheus API: %s\n", fetchErr.Error())
 
+			if contentType := recorder.Header().Get("Content-Type"); contentType != "" {
+				w.Header().Set("Content-Type", contentType)
+			}
 			w.WriteHeader(http.StatusOK)
 			w.Write(upstreamBody)
 			return
@@ -72,7 +67,9 @@ func AddMetricsHandler(handler http.HandlerFunc, host string, port int) http.Han
 			return
 		}
 
-		// log.Printf("Writing bytesOut: %s\n", bytesOut)
+		if contentType := recorder.Header().Get("Content-Type"); contentType != "" {
+			w.Header().Set("Content-Type", contentType)
+		}
 		w.WriteHeader(http.StatusOK)
 		w.Write(bytesOut)
 	}

--- a/gateway/metrics/add_metrics_test.go
+++ b/gateway/metrics/add_metrics_test.go
@@ -1,0 +1,81 @@
+package metrics
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type testFetchQuery struct {
+	res *VectorQueryResponse
+	err error
+}
+
+func (f testFetchQuery) Fetch(query string) (*VectorQueryResponse, error) {
+	return f.res, f.err
+}
+
+func TestAddMetricsHandlerServeHTTPReturnsContentTypeOfPassedInHandlerWhenFetchSucceeds(t *testing.T) {
+	contentTypes := []string{
+		"text/html",
+		"application/json",
+	}
+
+	for _, contentType := range contentTypes {
+		fetcher := testFetchQuery{
+			res: &VectorQueryResponse{},
+			err: nil,
+		}
+
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Content-Type", contentType)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]"))
+		}
+
+		metricsHandler := AddMetricsHandler(handler, fetcher)
+
+		w := httptest.NewRecorder()
+		r := &http.Request{}
+		metricsHandler.ServeHTTP(w, r)
+
+		expected := contentType
+		if contentType := w.Header().Get("Content-Type"); contentType != expected {
+			t.Errorf("content type header does not match: got %v want %v",
+				contentType, expected)
+		}
+	}
+}
+
+func TestAddMetricsHandlerServeHTTPReturnsContentTypeOfPassedInHandlerWhenFetchFails(t *testing.T) {
+	contentTypes := []string{
+		"text/html",
+		"application/json",
+	}
+
+	for _, contentType := range contentTypes {
+		fetcher := testFetchQuery{
+			res: nil,
+			err: errors.New("error"),
+		}
+
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Content-Type", contentType)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]"))
+		}
+
+		metricsHandler := AddMetricsHandler(handler, fetcher)
+
+		w := httptest.NewRecorder()
+		r := &http.Request{}
+		metricsHandler.ServeHTTP(w, r)
+
+		expected := contentType
+		if contentType := w.Header().Get("Content-Type"); contentType != expected {
+			t.Errorf("content type header does not match: got %v want %v",
+				contentType, expected)
+		}
+	}
+}

--- a/gateway/metrics/prometheus_query.go
+++ b/gateway/metrics/prometheus_query.go
@@ -7,6 +7,10 @@ import (
 	"net/http"
 )
 
+type FetchQuery interface {
+	Fetch(query string) (*VectorQueryResponse, error)
+}
+
 // PrometheusQuery a PrometheusQuery
 type PrometheusQuery struct {
 	Port   int
@@ -15,16 +19,16 @@ type PrometheusQuery struct {
 }
 
 // NewPrometheusQuery create a NewPrometheusQuery
-func NewPrometheusQuery(host string, port int, client *http.Client) PrometheusQuery {
+func NewPrometheusQuery(host string, port int) PrometheusQuery {
 	return PrometheusQuery{
-		Client: client,
+		Client: &http.Client{},
 		Host:   host,
 		Port:   port,
 	}
 }
 
 // Fetch queries aggregated stats
-func (q *PrometheusQuery) Fetch(query string) (*VectorQueryResponse, error) {
+func (q PrometheusQuery) Fetch(query string) (*VectorQueryResponse, error) {
 
 	req, reqErr := http.NewRequest("GET", fmt.Sprintf("http://%s:%d/api/v1/query/?query=%s", q.Host, q.Port, query), nil)
 	if reqErr != nil {

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -120,7 +120,8 @@ func main() {
 		faasHandlers.AsyncReport = internalHandlers.MakeAsyncReport(metricsOptions)
 	}
 
-	listFunctions := metrics.AddMetricsHandler(faasHandlers.ListFunctions, config.PrometheusHost, config.PrometheusPort)
+	prometheusQuery := metrics.NewPrometheusQuery(config.PrometheusHost, config.PrometheusPort)
+	listFunctions := metrics.AddMetricsHandler(faasHandlers.ListFunctions, prometheusQuery)
 
 	r := mux.NewRouter()
 


### PR DESCRIPTION
Signed-off-by: Alex Young <alex@heuris.io>

From testing master after #346 was merged: after the reader handler is wrapped in the metrics handler, headers such as Content-Type are not forwarded. That means that GET /system/functions always returns text/html even if the reader returns application/json. This can be observed in postman by issuing the above request. This is existing behaviour.

This PR addresses the issue above and adds unit tests that describe the changes.

Note that add_metrics_test.go is in the metrics package so that coverage of the add_metrics.go statements could be seen.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
