### PR TITLE
[Proposal] Move test directly into package and add test verbosity

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -15,7 +15,7 @@ COPY server.go      .
 
 # Run a gofmt and exclude all vendored code.
 RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))" \
-    && go test $(go list ./... | grep -v integration | grep -v /vendor/ | grep -v /template/) -cover \
+    && go test $(go list ./... | grep -v integration | grep -v /vendor/ | grep -v /template/) -v -cover \
     && CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o gateway .
 
 FROM alpine:3.6

--- a/gateway/handlers/reader_test.go
+++ b/gateway/handlers/reader_test.go
@@ -1,4 +1,4 @@
-package tests
+package handlers
 
 import (
 	"encoding/json"
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/openfaas/faas/gateway/handlers"
 	"github.com/openfaas/faas/gateway/metrics"
 	"github.com/openfaas/faas/gateway/requests"
 	"golang.org/x/net/context"
@@ -63,7 +62,7 @@ func TestReaderSuccessReturnsOK(t *testing.T) {
 		serviceListServices: []swarm.Service{},
 		serviceListError:    nil,
 	}
-	handler := handlers.MakeFunctionReader(m, c)
+	handler := MakeFunctionReader(m, c)
 
 	w := httptest.NewRecorder()
 	r := &http.Request{}
@@ -82,7 +81,7 @@ func TestReaderSuccessReturnsJsonContent(t *testing.T) {
 		serviceListServices: []swarm.Service{},
 		serviceListError:    nil,
 	}
-	handler := handlers.MakeFunctionReader(m, c)
+	handler := MakeFunctionReader(m, c)
 
 	w := httptest.NewRecorder()
 	r := &http.Request{}
@@ -101,7 +100,7 @@ func TestReaderSuccessReturnsCorrectBodyWithZeroFunctions(t *testing.T) {
 		serviceListServices: []swarm.Service{},
 		serviceListError:    nil,
 	}
-	handler := handlers.MakeFunctionReader(m, c)
+	handler := MakeFunctionReader(m, c)
 
 	w := httptest.NewRecorder()
 	r := &http.Request{}
@@ -146,7 +145,7 @@ func TestReaderSuccessReturnsCorrectBodyWithOneFunction(t *testing.T) {
 		serviceListServices: services,
 		serviceListError:    nil,
 	}
-	handler := handlers.MakeFunctionReader(m, c)
+	handler := MakeFunctionReader(m, c)
 
 	w := httptest.NewRecorder()
 	r := &http.Request{}
@@ -175,7 +174,7 @@ func TestReaderErrorReturnsInternalServerError(t *testing.T) {
 		serviceListServices: nil,
 		serviceListError:    errors.New("error"),
 	}
-	handler := handlers.MakeFunctionReader(m, c)
+	handler := MakeFunctionReader(m, c)
 
 	w := httptest.NewRecorder()
 	r := &http.Request{}
@@ -194,7 +193,7 @@ func TestReaderErrorReturnsCorrectBody(t *testing.T) {
 		serviceListServices: nil,
 		serviceListError:    errors.New("error"),
 	}
-	handler := handlers.MakeFunctionReader(m, c)
+	handler := MakeFunctionReader(m, c)
 
 	w := httptest.NewRecorder()
 	r := &http.Request{}


### PR DESCRIPTION
Signed-off-by: Alex Young <alex@heuris.io>

To see coverage for hander tests I've moved reader_test.go into the handlers package. Now instead of the build showing:

```
?   	github.com/openfaas/faas/gateway/handlers	[no test files]
```

it shows:

```
ok  	github.com/openfaas/faas/gateway/handlers	0.023s	coverage: 5.3% of statements
```

I've also added the `-v` flag to the go test command to show tests that have passed/failed like in the watchdog build.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
