### PR TITLE
Set content-type for mixed-in Prometheus results

### DIFF
--- a/gateway/metrics/prometheus_query.go
+++ b/gateway/metrics/prometheus_query.go
@@ -14,6 +14,10 @@ type PrometheusQuery struct {
 	Client *http.Client
 }
 
+type PrometheusQueryFetcher interface {
+	Fetch(query string) (*VectorQueryResponse, error)
+}
+
 // NewPrometheusQuery create a NewPrometheusQuery
 func NewPrometheusQuery(host string, port int, client *http.Client) PrometheusQuery {
 	return PrometheusQuery{
@@ -24,7 +28,7 @@ func NewPrometheusQuery(host string, port int, client *http.Client) PrometheusQu
 }
 
 // Fetch queries aggregated stats
-func (q *PrometheusQuery) Fetch(query string) (*VectorQueryResponse, error) {
+func (q PrometheusQuery) Fetch(query string) (*VectorQueryResponse, error) {
 
 	req, reqErr := http.NewRequest("GET", fmt.Sprintf("http://%s:%d/api/v1/query/?query=%s", q.Host, q.Port, query), nil)
 	if reqErr != nil {

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -120,7 +120,8 @@ func main() {
 		faasHandlers.AsyncReport = internalHandlers.MakeAsyncReport(metricsOptions)
 	}
 
-	listFunctions := metrics.AddMetricsHandler(faasHandlers.ListFunctions, config.PrometheusHost, config.PrometheusPort)
+	prometheusQuery := metrics.NewPrometheusQuery(config.PrometheusHost, config.PrometheusPort, &http.Client{})
+	listFunctions := metrics.AddMetricsHandler(faasHandlers.ListFunctions, prometheusQuery)
 
 	r := mux.NewRouter()
 

--- a/gateway/tests/add_metrics_test.go
+++ b/gateway/tests/add_metrics_test.go
@@ -1,0 +1,94 @@
+package tests
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openfaas/faas/gateway/metrics"
+	"github.com/openfaas/faas/gateway/requests"
+)
+
+type FakePrometheusQueryFetcher struct {
+}
+
+func (q FakePrometheusQueryFetcher) Fetch(query string) (*metrics.VectorQueryResponse, error) {
+
+	return &metrics.VectorQueryResponse{}, nil
+}
+
+func makeFakePrometheusQueryFetcher() FakePrometheusQueryFetcher {
+	return FakePrometheusQueryFetcher{}
+}
+
+func Test_PrometheusMetrics_MixedInto_Services(t *testing.T) {
+	functionsHandler := makeFunctionsHandler()
+	fakeQuery := makeFakePrometheusQueryFetcher()
+
+	handler := metrics.AddMetricsHandler(functionsHandler, fakeQuery)
+
+	rr := httptest.NewRecorder()
+	request, _ := http.NewRequest(http.MethodGet, "/system/functions", nil)
+	handler.ServeHTTP(rr, request)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	if rr.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("Want application/json content-type, got: %s", rr.Header().Get("Content-Type"))
+	}
+	if len(rr.Body.String()) == 0 {
+		t.Errorf("Want content-length > 0, got: %d", len(rr.Body.String()))
+	}
+
+}
+
+func Test_FunctionsHandler_ReturnsJSONAndOneFunction(t *testing.T) {
+	functionsHandler := makeFunctionsHandler()
+
+	rr := httptest.NewRecorder()
+	request, err := http.NewRequest(http.MethodGet, "/system/functions", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	functionsHandler.ServeHTTP(rr, request)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	if rr.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("Want application/json content-type, got: %s", rr.Header().Get("Content-Type"))
+	}
+
+	if len(rr.Body.String()) == 0 {
+		t.Errorf("Want content-length > 0, got: %d", len(rr.Body.String()))
+	}
+
+}
+
+func makeFunctionsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		functions := []requests.Function{
+			requests.Function{
+				Name:     "echo",
+				Replicas: 0,
+			},
+		}
+		bytesOut, marshalErr := json.Marshal(&functions)
+		if marshalErr != nil {
+			log.Fatal(marshalErr.Error())
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(bytesOut)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
Set content-type for mixed-in Prometheus results

## Description
<!--- Describe your changes in detail -->

Metrics are sometimes sent back as text/plain, this corrects the Content-Length and begins unit test coverage.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Suggestion by @nullseed 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tested and full build

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
