### PR TITLE
Return labels in functions list endpoint

### DIFF
--- a/gateway/handlers/reader.go
+++ b/gateway/handlers/reader.go
@@ -50,12 +50,15 @@ func MakeFunctionReader(metricsOptions metrics.MetricOptions, c client.ServiceAP
 					}
 				}
 
+				// Required (copy by value)
+				labels := service.Spec.Annotations.Labels
 				f := requests.Function{
 					Name:            service.Spec.Name,
 					Image:           service.Spec.TaskTemplate.ContainerSpec.Image,
 					InvocationCount: 0,
 					Replicas:        *service.Spec.Mode.Replicated.Replicas,
 					EnvProcess:      envProcess,
+					Labels:          &labels,
 				}
 
 				functions = append(functions, f)

--- a/gateway/requests/requests.go
+++ b/gateway/requests/requests.go
@@ -67,6 +67,10 @@ type Function struct {
 	InvocationCount float64 `json:"invocationCount"` // TODO: shouldn't this be int64?
 	Replicas        uint64  `json:"replicas"`
 	EnvProcess      string  `json:"envProcess"`
+
+	// Labels are metadata for functions which may be used by the
+	// back-end for making scheduling or routing decisions
+	Labels *map[string]string `json:"labels"`
 }
 
 // AsyncReport is the report from a function executed on a queue worker.

--- a/gateway/tests/reader_test.go
+++ b/gateway/tests/reader_test.go
@@ -116,6 +116,10 @@ func TestReaderSuccessReturnsCorrectBodyWithZeroFunctions(t *testing.T) {
 
 func TestReaderSuccessReturnsCorrectBodyWithOneFunction(t *testing.T) {
 	replicas := uint64(5)
+	labels := map[string]string{
+		"function": "bar",
+	}
+
 	services := []swarm.Service{
 		swarm.Service{
 			Spec: swarm.ServiceSpec{
@@ -125,17 +129,16 @@ func TestReaderSuccessReturnsCorrectBodyWithOneFunction(t *testing.T) {
 					},
 				},
 				Annotations: swarm.Annotations{
-					Name: "bar",
+					Name:   "bar",
+					Labels: labels,
 				},
 				TaskTemplate: swarm.TaskSpec{
 					ContainerSpec: swarm.ContainerSpec{
 						Env: []string{
 							"fprocess=bar",
 						},
-						Image: "foo/bar:latest",
-						Labels: map[string]string{
-							"function": "bar",
-						},
+						Image:  "foo/bar:latest",
+						Labels: labels,
 					},
 				},
 			},
@@ -159,6 +162,9 @@ func TestReaderSuccessReturnsCorrectBodyWithOneFunction(t *testing.T) {
 			InvocationCount: 0,
 			Replicas:        5,
 			EnvProcess:      "bar",
+			Labels: &map[string]string{
+				"function": "bar",
+			},
 		},
 	}
 	marshalled, _ := json.Marshal(functions)


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

New feature - Return labels through function reader

## Motivation and Context

We can current input / set labels, but this allows the metadata to be consumed by other clients such as a gateway-connector by reading /system/functions.

## How Has This Been Tested?

Tested by adding new labels to samples.yml in the faas-cli.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Related: https://github.com/openfaas/faas-netes/pull/75