### PR TITLE
Removes depends_on tag from docker-compose.yml files and documentation

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -52,8 +52,6 @@ Update the Docker stack with this:
         image: alexellis2/faas-markdownrender:latest
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
 ```
@@ -77,8 +75,6 @@ Update your Docker stack with this definition:
         image: alexellis2/faas-alpinefunction:latest
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -20,9 +20,6 @@ services:
         command: "-config.file=/etc/prometheus/prometheus.yml -storage.local.path=/prometheus -storage.local.memory-chunks=10000 --alertmanager.url=http://alertmanager:9093"
         ports:
             - 9090:9090
-        depends_on:
-            - gateway
-            - alertmanager
         environment:
             no_proxy: "gateway"
         networks:

--- a/docker-compose.armhf.yml
+++ b/docker-compose.armhf.yml
@@ -23,9 +23,6 @@ services:
         command: "-config.file=/etc/prometheus/prometheus.yml -storage.local.path=/prometheus -storage.local.memory-chunks=10000 --alertmanager.url=http://alertmanager:9093"
         ports:
             - 9090:9090
-        depends_on:
-            - gateway
-            - alertmanager
         environment:
             no_proxy:   "gateway"
         networks:
@@ -56,8 +53,6 @@ services:
         image: functions/nodeinfo:latest-armhf
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:
@@ -68,8 +63,6 @@ services:
         image: functions/markdownrender:latest-armhf
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:
@@ -79,8 +72,6 @@ services:
         image: functions/alpine:latest-armhf
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:
@@ -91,8 +82,6 @@ services:
         image: functions/alpine:latest-armhf
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:

--- a/docker-compose.extended.armhf.yml
+++ b/docker-compose.extended.armhf.yml
@@ -12,9 +12,6 @@ services:
             dnsrr: "true"  # Temporarily use dnsrr in place of VIP while issue persists on PWD
             faas_nats_address: "nats"
             faas_nats_port: 4222
-        # Start Add for NATS Streaming
-        depends_on:
-            - nats
         deploy:
             restart_policy:
                 condition: on-failure
@@ -64,9 +61,6 @@ services:
         command: "-config.file=/etc/prometheus/prometheus.yml -storage.local.path=/prometheus -storage.local.memory-chunks=10000 --alertmanager.url=http://alertmanager:9093"
         ports:
             - 9090:9090
-        depends_on:
-            - gateway
-            - alertmanager
         environment:
             no_proxy:   "gateway"
         networks:
@@ -96,8 +90,6 @@ services:
         image: functions/markdownrender:latest-armhf
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:

--- a/docker-compose.extended.yml
+++ b/docker-compose.extended.yml
@@ -12,9 +12,6 @@ services:
             dnsrr: "true"  # Temporarily use dnsrr in place of VIP while issue persists on PWD
             faas_nats_address: "nats"
             faas_nats_port: 4222
-        # Start Add for NATS Streaming
-        depends_on:
-            - nats
         deploy:
             resources:
                 limits:
@@ -77,9 +74,6 @@ services:
         command: "-config.file=/etc/prometheus/prometheus.yml -storage.local.path=/prometheus -storage.local.memory-chunks=10000 --alertmanager.url=http://alertmanager:9093"
         ports:
             - 9090:9090
-        depends_on:
-            - gateway
-            - alertmanager
         environment:
             no_proxy: "gateway"
         networks:
@@ -123,8 +117,6 @@ services:
         image: functions/hubstats:latest
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:
@@ -145,8 +137,6 @@ services:
         image: functions/nodeinfo:latest
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:
@@ -167,8 +157,6 @@ services:
         image: functions/alpine:latest
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,9 +34,6 @@ services:
         command: "-config.file=/etc/prometheus/prometheus.yml -storage.local.path=/prometheus -storage.local.memory-chunks=10000 --alertmanager.url=http://alertmanager:9093"
         ports:
             - 9090:9090
-        depends_on:
-            - gateway
-            - alertmanager
         environment:
             no_proxy: "gateway"
         networks:
@@ -80,8 +77,6 @@ services:
         image: functions/webhookstash:latest
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:
@@ -97,8 +92,6 @@ services:
         image: functions/hubstats:latest
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:
@@ -115,8 +108,6 @@ services:
         image: functions/nodeinfo:latest
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:
@@ -133,8 +124,6 @@ services:
         image: functions/alpine:latest
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:
@@ -153,8 +142,6 @@ services:
         labels:
             function: "true"
             com.faas.max_replicas: "10"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:
@@ -172,8 +159,6 @@ services:
         image: functions/alpine:latest
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:
@@ -191,8 +176,6 @@ services:
         image: functions/alpine:latest
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:
@@ -209,8 +192,6 @@ services:
         image: functions/markdown-render:latest
         labels:
             function: "true"
-        depends_on:
-            - gateway
         networks:
             - functions
         environment:


### PR DESCRIPTION
## Description
Removes depends_on tag from docker-compose.yml files and documentation

## Motivation and Context
Fixes #198, and updated `DEV.md` documentation accordingly.


## How Has This Been Tested?
Executing `docker stack --compose-file=docker-compose.yml deploy` for all the changed files and verifying all the services were up and runnin. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.