### PR TITLE
Fix JSON serialization relying on response content

### DIFF
--- a/gateway/assets/script/bootstrap.js
+++ b/gateway/assets/script/bootstrap.js
@@ -59,8 +59,8 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
 
             $http(options)
                 .then(function(response) {
-                    if ($scope.invocation && $scope.invocation.contentType == "json") {
-                        $scope.invocationResponse = JSON.stringify(response.data, -1, "  ");
+                    if (typeof response.data == 'object') {
+                        $scope.invocationResponse = JSON.stringify(response.data, null, 2);
                     } else {
                         $scope.invocationResponse = response.data;
                     }


### PR DESCRIPTION
Signed-off-by: Javier Revillas <jrevillas@massivedynamic.io>

## Description
This will render JSON responses from functions in accordance with #398.

## Motivation and context
Enables the possibility to fire functions that consume plain text and return JSON. Fixes issue #398.
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How has this been tested?
This code has been tested following instructions from `contrib/HACK.md` and using the `SentimentAnalysis` function as a reference.

![](https://i.imgur.com/zVpw4mt.gif)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.