### PR TITLE
fix k8s fass-netes deploy docs, namespace.yml is at the root of the repo.

### DIFF
--- a/guide/deployment_k8s.md
+++ b/guide/deployment_k8s.md
@@ -57,7 +57,7 @@ This command is split into two parts so that the OpenFaaS namespaces are always 
 
 ```
 $ cd faas-netes && \
- kubectl apply -f ./yaml/namespaces.yml && \
+ kubectl apply -f ./namespaces.yml && \
  kubectl apply -f ./yaml
 ```
 


### PR DESCRIPTION
Small k8s faas-netes installation docs fix, namespace.yml is at the root of the project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs fix (non-breaking change which fixes an issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
