### PR TITLE
Update HACK.md in accordance with #454

### DIFF
--- a/contrib/HACK.md
+++ b/contrib/HACK.md
@@ -41,7 +41,8 @@ Now you can run the gateway as its own container via `docker run` and bind-mount
 
 ```
 $ docker service rm func_gateway
-$ docker run --name func_gateway -v `pwd`/gateway/assets:/root/assets \
+$ docker run --name func_gateway -e "functions_provider_url=http://faas-swarm:8080/" \
+  -v `pwd`/gateway/assets:/home/app/assets \
   -v "/var/run/docker.sock:/var/run/docker.sock" \
   -p 8080:8080 --network=func_functions \
   -d functions/gateway:latest-dev


### PR DESCRIPTION
## Description
This updates the documentation needed to manually spin up a container for the gateway. The updated command will mount the gateway into the unprivileged user's home directory. This will also set a new environment variable: `functions_provider_url`.

## How has this been tested?
This command has been tested on a local environment with MacOS High Sierra 10.13.3 and Docker CE 18.02.0-ce-rc2-mac51 (22446).