### PR TITLE
Moved supported Docker version to 17.06 to enable 3.3 of compose

### DIFF
--- a/guide/deployment_swarm.md
+++ b/guide/deployment_swarm.md
@@ -8,7 +8,7 @@ These instructions are for a development environment. If you plan to expose Open
 
 ## Initialize Swarm Mode
 
-You can create a single-host Docker Swarm on your laptop with a single command. You don't need any additional software to Docker 17.05 or greater. You can also run these commands on a Linux VM or cloud host.
+You can create a single-host Docker Swarm on your laptop with a single command. You don't need any additional software to Docker 17.06 or greater. You can also run these commands on a Linux VM or cloud host.
 
 This is how you initialize your master node:
 

--- a/guide/deployment_swarm_arm.md
+++ b/guide/deployment_swarm_arm.md
@@ -26,7 +26,7 @@ When running OpenFaaS on ARM a key consideration is that we need to use arm base
 
 ### Initialize Swarm Mode
 
-You can create a single-host Docker Swarm on your ARM device with a single command. You don't need any additional software to Docker 17.05 or greater.
+You can create a single-host Docker Swarm on your ARM device with a single command. You don't need any additional software to Docker 17.06 or greater.
 
 This is how you initialize your master node:
 


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

## Description
Simple change to the swarm guides to accommodate Compose 3.3.  Fixes #499

## Motivation and Context
see #499 
- [ x ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
17.06 is detailed by docker as supporting compose 3.3.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Change to Guides/Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
