### PR TITLE
Fixed UI to use relative paths for ajax requests in order to work with `kube proxy`

### DIFF
--- a/gateway/assets/script/bootstrap.js
+++ b/gateway/assets/script/bootstrap.js
@@ -53,7 +53,7 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
             }
 
             var options = {
-                url: "/function/" + $scope.selectedFunction.name,
+                url: "../function/" + $scope.selectedFunction.name,
                 data: $scope.invocation.request,
                 method: "POST",
                 headers: { "Content-Type": requestContentType },
@@ -143,7 +143,7 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
             var previous = $scope.functions;
 
             var cl = function(previousItems) {
-                $http.get("/system/functions").then(function(response) {
+                $http.get("../system/functions").then(function(response) {
                     if (response && response.data) {
                         if (previousItems.length != response.data.length) {
                             $scope.functions = response.data;
@@ -164,7 +164,7 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
         }
 
         var fetch = function() {
-            $http.get("/system/functions").then(function(response) {
+            $http.get("../system/functions").then(function(response) {
                 $scope.functions = response.data;
             });
         };
@@ -227,7 +227,7 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
 
             $scope.createFunc = function() {
                 var options = {
-                    url: "/system/functions",
+                    url: "../system/functions",
                     data: $scope.item,
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
@@ -268,7 +268,7 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
             $mdDialog.show(confirm)
                 .then(function() {
                     var options = {
-                        url: "/system/functions",
+                        url: "../system/functions",
                         data: {
                             functionName: $scope.selectedFunction.name
                         },


### PR DESCRIPTION
Signed-off-by: Ken Fukuyama <fukuyama@supersoftware.co.jp>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Because the ajax requests used the paths from the root, the gateway UI didn't work correctly via `kube proxy`. Using relative paths for the requests would solve this problem.
This is the [same fix](https://github.com/containous/traefik/pull/492) traefik has made, too.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
People who use the gateway via `kube proxy` cannot use the UI currently.
This fixes issue #519.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've spun up a kubernetes cluster with docker on mac. Deployed openfaas and checked

* Create
* Delete
* Invoke (downloaded an image, too)

both with and without `kube proxy`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
