### PR TITLE
Populate `Http_Cookie` env-var if Cookie header is set.

### DIFF
--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -203,6 +203,11 @@ func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request,
 func getAdditionalEnvs(config *WatchdogConfig, r *http.Request, method string) []string {
 	var envs []string
 
+	cookies := r.Cookies()
+	if len(cookies) != 0 {
+		envs = append(envs, fmt.Sprintf("Http_Cookies=%s", cookies[0].String()))
+	}
+
 	if config.cgiHeaders {
 		envs = os.Environ()
 		for k, v := range r.Header {

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -205,7 +205,7 @@ func getAdditionalEnvs(config *WatchdogConfig, r *http.Request, method string) [
 
 	cookies := r.Cookies()
 	if len(cookies) != 0 {
-		envs = append(envs, fmt.Sprintf("Http_Cookies=%s", cookies[0].String()))
+		envs = append(envs, fmt.Sprintf("Http_Cookie=%s", cookies[0].String()))
 	}
 
 	if config.cgiHeaders {


### PR DESCRIPTION
## Description
Populate Http_cookie envvar if Cookie header is set.

Note that this ignores all but the first Cookie header, per [rfc6265#section-5.4]( https://tools.ietf.org/html/rfc6265#section-5.4) which stipulates:

> When the user agent generates an HTTP request, the user agent MUST
> NOT attach more than one Cookie header field.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change (#538)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built function using updated watchdog invoking env.

![image](https://user-images.githubusercontent.com/83862/36642576-3cff70a2-1a39-11e8-9430-e605b342e4b8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
