### PR TITLE
added go duration support for timeout config in watchdog

### DIFF
--- a/watchdog/config_test.go
+++ b/watchdog/config_test.go
@@ -162,16 +162,34 @@ func TestRead_ReadAndWriteTimeoutConfig(t *testing.T) {
 	}
 }
 
+func TestRead_ReadAndWriteTimeoutDurationConfig(t *testing.T) {
+	defaults := NewEnvBucket()
+	defaults.Setenv("read_timeout", "20s")
+	defaults.Setenv("write_timeout", "1m30s")
+
+	readConfig := ReadConfig{}
+	config := readConfig.Read(defaults)
+
+	if (config.readTimeout) != time.Duration(20)*time.Second {
+		t.Logf("readTimeout incorrect, got: %d\n", config.readTimeout)
+		t.Fail()
+	}
+	if (config.writeTimeout) != time.Duration(90)*time.Second {
+		t.Logf("writeTimeout incorrect, got: %d\n", config.writeTimeout)
+		t.Fail()
+	}
+}
+
 func TestRead_ExecTimeoutConfig(t *testing.T) {
 	defaults := NewEnvBucket()
-	defaults.Setenv("exec_timeout", "3")
+	defaults.Setenv("exec_timeout", "3s")
 
 	readConfig := ReadConfig{}
 	config := readConfig.Read(defaults)
 
 	want := time.Duration(3) * time.Second
 	if (config.execTimeout) != want {
-		t.Logf("readTimeout incorrect, got: %d - want: %s\n", config.execTimeout, want)
+		t.Logf("execTimeout incorrect, got: %d - want: %s\n", config.execTimeout, want)
 		t.Fail()
 	}
 }


### PR DESCRIPTION
added go duration support for read_timeout, write_timeout, exec_timeout in watchdog

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
