### PR TITLE
Expose function endpoint from underlying provider

### DIFF
--- a/api-docs/swagger.yml
+++ b/api-docs/swagger.yml
@@ -197,6 +197,22 @@ paths:
           description: Function not found
         '500':
           description: Error connecting to function
+  '/system/function/{functionName}':
+    get:
+      summary: Get a summary of an OpenFaaS function
+      parameters:
+        - in: path
+          name: functionName
+          description: Function name
+          type: string
+          required: true
+      responses:
+        '200':
+          description: Function definition
+        '404':
+          description: Function not found
+        '500':
+          description: Error querying function
 definitions:
   DeleteFunctionRequest:
     type: object

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: functions/gateway:0.7.2
+        image: functions/gateway:0.7.3
         networks:
             - functions
         environment:

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -50,6 +50,8 @@ func main() {
 	faasHandlers.DeleteFunction = internalHandlers.MakeForwardingProxyHandler(reverseProxy, &metricsOptions)
 	faasHandlers.UpdateFunction = internalHandlers.MakeForwardingProxyHandler(reverseProxy, &metricsOptions)
 
+	queryFunction := internalHandlers.MakeForwardingProxyHandler(reverseProxy, &metricsOptions)
+
 	alertHandler := plugin.NewExternalServiceQuery(*config.FunctionsProviderURL)
 	faasHandlers.Alert = internalHandlers.MakeAlertHandler(alertHandler)
 
@@ -77,6 +79,7 @@ func main() {
 
 	r.HandleFunc("/system/alert", faasHandlers.Alert)
 
+	r.HandleFunc("/system/function/{name:[-a-zA-Z_0-9]+}", queryFunction).Methods("GET")
 	r.HandleFunc("/system/functions", listFunctions).Methods("GET")
 	r.HandleFunc("/system/functions", faasHandlers.DeployFunction).Methods("POST")
 	r.HandleFunc("/system/functions", faasHandlers.DeleteFunction).Methods("DELETE")


### PR DESCRIPTION
Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Expose function endpoint from underlying provider

This means a new route: `/system/function/{name:[-a-zA-Z_0-9]+}`

## Motivation and Context

Required to expose underlying function information for a single function.

Todo:
- [x] Add proxying route to underlying provider route
- [x] Update Swagger
- [ ] Combine metrics from Prometheus into `invocationCount`, otherwise it'll be `0` always

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with the Swarm provider:

```
$ curl 127.0.0.1:8080/system/function/func_base64 | jq
{
  "name": "func_base64",
  "image": "functions/alpine:latest@sha256:4145602d726a93ed2b393159bb834342a60dcef775729db14bef631c2e90606f",
  "invocationCount": 0,
  "replicas": 1,
  "envProcess": "base64",
  "labels": {
    "com.docker.stack.image": "functions/alpine:latest",
    "com.docker.stack.namespace": "func"
  }
}
```

When function not found:

```
$ curl 127.0.0.1:8080/system/function/doesnt_exist -i
HTTP/1.1 404 Not Found
Content-Length: 0
Content-Type: text/plain; charset=utf-8
Date: Wed, 28 Feb 2018 21:25:39 GMT
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

cc/ @imikushin
