### PR TITLE
Add AvailableReplicas field to requests.Function

### DIFF
--- a/gateway/requests/requests.go
+++ b/gateway/requests/requests.go
@@ -57,6 +57,9 @@ type Function struct {
 	Replicas        uint64  `json:"replicas"`
 	EnvProcess      string  `json:"envProcess"`
 
+	// AvailableReplicas is the count of replicas ready to receive invocations as reported by the back-end
+	AvailableReplicas uint64 `json:"availableReplicas"`
+
 	// Labels are metadata for functions which may be used by the
 	// back-end for making scheduling or routing decisions
 	Labels *map[string]string `json:"labels"`


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add AvailableReplicas field to `requests.Function` struct. 

## Motivation and Context
Without this field (or equivalent), it's impossible to tell if the function is ready to serve incoming invocations. 

Looks like openfaas/faas-netes#67 is blocked until this change is in. 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
```
$ go test ./gateway/{tests,requests}
``` 

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
