### PR TITLE
Make UI block "Invoke" button until function reports readiness

### DIFF
--- a/gateway/assets/index.html
+++ b/gateway/assets/index.html
@@ -89,11 +89,9 @@
                                 </md-button>
 
                             </div>
+
                             <div layout-gt-sm="row">
-                                <md-input-container class="md-icon-float md-block">
-                                    <label>Status</label>
-                                    <input ng-model="isReady(function)" type="text" readonly="readonly">
-                                </md-input-container>
+                                <ready-input></ready-input>
 
                                 <md-input-container class="md-icon-float md-block">
                                     <label>Replicas</label>

--- a/gateway/assets/index.html
+++ b/gateway/assets/index.html
@@ -91,9 +91,15 @@
                             </div>
                             <div layout-gt-sm="row">
                                 <md-input-container class="md-icon-float md-block">
+                                    <label>Status</label>
+                                    <input ng-model="isReady(function)" type="text" readonly="readonly">
+                                </md-input-container>
+
+                                <md-input-container class="md-icon-float md-block">
                                     <label>Replicas</label>
                                     <input ng-model="function.replicas" type="text" readonly="readonly">
                                 </md-input-container>
+
                                 <md-input-container class="md-block" flex-gt-sm>
                                     <label>Invocation count</label>
                                     <input ng-model="function.invocationCount" type="text" readonly="readonly">
@@ -124,7 +130,7 @@
                             </span>
                             <div layout-gt-sm="row">
                                 <md-input-container class="md-block" flex-gt-sm>
-                                    <button ng-click="fireRequest()" class="md-raised md-button md-ink-ripple" type="button" ng-disabled="invocationInProgress">
+                                    <button ng-click="fireRequest()" class="md-raised md-button md-ink-ripple" type="button" ng-disabled="invocationInProgress || (selectedFunction && !selectedFunction.ready)">
                                         <span class="ng-scope">Invoke</span><div class="md-ripple-container"></div>
                                     </button>
                                 </md-input-container>

--- a/gateway/assets/index.html
+++ b/gateway/assets/index.html
@@ -72,7 +72,7 @@
                 <div flex></div>
             </md-content>
 
-            <md-content flex layout="column" ng-repeat="function in functions" ng-show="function.name == selectedFunction.name">
+            <md-content flex layout="column" ng-repeat="function in functions" ng-if="function.name == selectedFunction.name">
 
                 <md-card md-theme="default" md-theme-watch>
                     <md-card-title>

--- a/gateway/assets/index.html
+++ b/gateway/assets/index.html
@@ -91,7 +91,10 @@
                             </div>
 
                             <div layout-gt-sm="row">
-                                <ready-input></ready-input>
+                                <md-input-container class="md-icon-float md-block">
+                                   <label>Status</label>
+                                   <input value="{{ function.ready ? 'Ready' : 'Not ready' }}" type="text" readonly="readonly">
+                                </md-input-container>
 
                                 <md-input-container class="md-icon-float md-block">
                                     <label>Replicas</label>

--- a/gateway/assets/script/bootstrap.js
+++ b/gateway/assets/script/bootstrap.js
@@ -36,24 +36,23 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
         }
 
         $scope.invocation.request = "";
-        $scope.isFunctionReady = "Querying";
-        $scope.fetchFunctionsDelay = 3500;
-        $scope.queryFunctionDelay = 2500;
+        var fetchFunctionsDelay = 3500;
+        var queryFunctionDelay = 2500;
         
-        $scope.fetchFunctionsInterval = setInterval(function() {
+        var fetchFunctionsInterval = setInterval(function() {
             refreshData();
-        }, $scope.fetchFunctionsDelay);
+        }, fetchFunctionsDelay);
 
-        $scope.queryFunctionInterval = setInterval(function() {
+        var queryFunctionInterval = setInterval(function() {
             if($scope.selectedFunction && $scope.selectedFunction.name) {
                 refreshFunction($scope.selectedFunction);
             }
-        }, $scope.queryFunctionDelay);
+        }, queryFunctionDelay);
 
         var refreshFunction = function(functionInstance) {
             $http.get("../system/function/" + functionInstance.name)
             .then(function(response) {
-                functionInstance.ready = (response.data && response.data.availableReplicas && response.data.availableReplicas >0);
+                functionInstance.ready = (response.data && response.data.availableReplicas && response.data.availableReplicas > 0);
             })
             .catch(function(err) {
                 console.error(err);

--- a/gateway/assets/script/bootstrap.js
+++ b/gateway/assets/script/bootstrap.js
@@ -31,11 +31,37 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
             labels: {}
         };
 
+        $scope.isReady = function(selectedFunction) {
+            if(selectedFunction.ready != undefined && selectedFunction.ready) {
+                return "Ready";
+            }
+            return "Querying..";
+        }
+
         $scope.invocation.request = "";
 
-        setInterval(function() {
+        $scope.fetchFunctionsDelay = 3500;
+        $scope.queryFunctionDelay = 2500;
+        
+        $scope.fetchFunctionsInterval = setInterval(function() {
             refreshData();
-        }, 1000);
+        }, $scope.fetchFunctionsDelay);
+
+        $scope.queryFunctionInterval = setInterval(function() {
+            if($scope.selectedFunction && $scope.selectedFunction.name) {
+                refreshFunction($scope.selectedFunction);
+            }
+        }, $scope.queryFunctionDelay);
+
+        var refreshFunction = function(functionInstance) {
+            $http.get("../system/function/" + functionInstance.name)
+            .then(function(response) {
+                functionInstance.ready = (response.data && response.data.availableReplicas && response.data.availableReplicas >0);
+            })
+            .catch(function(err) {
+                console.error(err);
+            });
+        };
 
         var showPostInvokedToast = function(message, duration) {
             $mdToast.show(

--- a/gateway/assets/script/bootstrap.js
+++ b/gateway/assets/script/bootstrap.js
@@ -4,8 +4,8 @@
 
 var app = angular.module('faasGateway', ['ngMaterial', 'faasGateway.funcStore']);
 
-app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$mdDialog', '$mdToast', '$mdSidenav',
-    function($scope, $log, $http, $location, $timeout, $mdDialog, $mdToast, $mdSidenav) {
+app.controller("home", ['$scope', '$log', '$http', '$location', '$interval', '$filter', '$mdDialog', '$mdToast', '$mdSidenav',
+    function($scope, $log, $http, $location, $interval, $filter, $mdDialog, $mdToast, $mdSidenav) {
         var newFuncTabIdx = 0;
         $scope.functions = [];
         $scope.invocationInProgress = false;
@@ -31,19 +31,15 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
             labels: {}
         };
 
-        $scope.isReady = function(selectedFunction) {
-            return (selectedFunction.ready != undefined && selectedFunction.ready == true);
-        }
-
         $scope.invocation.request = "";
         var fetchFunctionsDelay = 3500;
         var queryFunctionDelay = 2500;
         
-        var fetchFunctionsInterval = setInterval(function() {
+        var fetchFunctionsInterval = $interval(function() {
             refreshData();
         }, fetchFunctionsDelay);
 
-        var queryFunctionInterval = setInterval(function() {
+        var queryFunctionInterval = $interval(function() {
             if($scope.selectedFunction && $scope.selectedFunction.name) {
                 refreshFunction($scope.selectedFunction);
             }
@@ -169,6 +165,14 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
                     if (response && response.data) {
                         if (previousItems.length != response.data.length) {
                             $scope.functions = response.data;
+                            
+                            // update the selected function object because the newly fetched object from the API becomes a different object
+                            var filteredSelectedFunction = $filter('filter')($scope.functions, {name: $scope.selectedFunction.name}, true);
+                            if (filteredSelectedFunction && filteredSelectedFunction.length > 0) {
+                                $scope.selectedFunction = filteredSelectedFunction[0];
+                            } else {
+                                $scope.selectedFunction = undefined;
+                            }
                         } else {
                             for (var i = 0; i < $scope.functions.length; i++) {
                                 for (var j = 0; j < response.data.length; j++) {

--- a/gateway/assets/script/bootstrap.js
+++ b/gateway/assets/script/bootstrap.js
@@ -4,6 +4,16 @@
 
 var app = angular.module('faasGateway', ['ngMaterial', 'faasGateway.funcStore']);
 
+app.directive("readyInput", function() {
+    return {
+        "restrict": "E",
+        "template": '<md-input-container class="md-icon-float md-block">'+
+        '   <label>Status</label>' +
+        '   <input value="{{ function.ready ? \'Ready\' : \'Querying\' }}" type="text" readonly="readonly">' +
+        '</md-input-container>'
+    };
+});
+
 app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$mdDialog', '$mdToast', '$mdSidenav',
     function($scope, $log, $http, $location, $timeout, $mdDialog, $mdToast, $mdSidenav) {
         var newFuncTabIdx = 0;
@@ -32,14 +42,11 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$md
         };
 
         $scope.isReady = function(selectedFunction) {
-            if(selectedFunction.ready != undefined && selectedFunction.ready) {
-                return "Ready";
-            }
-            return "Querying..";
+            return (selectedFunction.ready != undefined && selectedFunction.ready == true);
         }
 
         $scope.invocation.request = "";
-
+        $scope.isFunctionReady = "Querying";
         $scope.fetchFunctionsDelay = 3500;
         $scope.queryFunctionDelay = 2500;
         

--- a/gateway/assets/script/bootstrap.js
+++ b/gateway/assets/script/bootstrap.js
@@ -4,16 +4,6 @@
 
 var app = angular.module('faasGateway', ['ngMaterial', 'faasGateway.funcStore']);
 
-app.directive("readyInput", function() {
-    return {
-        "restrict": "E",
-        "template": '<md-input-container class="md-icon-float md-block">'+
-        '   <label>Status</label>' +
-        '   <input value="{{ function.ready ? \'Ready\' : \'Querying\' }}" type="text" readonly="readonly">' +
-        '</md-input-container>'
-    };
-});
-
 app.controller("home", ['$scope', '$log', '$http', '$location', '$timeout', '$mdDialog', '$mdToast', '$mdSidenav',
     function($scope, $log, $http, $location, $timeout, $mdDialog, $mdToast, $mdSidenav) {
         var newFuncTabIdx = 0;


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes #555 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with faas-netes which provides `availableReplicas` on the `/system/function/<name>` endpoint.

This change requires a change to faas-swarm and faas-nomad to report `availableReplicas` = 1 all the time, or optionally when the underlying container is ready.

Update the gateway to the `functions/gateway:pr554` for testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Breaking change to UI only, not to the API.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
