### PR TITLE
Use Go context to enforce upstream timeouts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,9 @@ services:
             - functions
         environment:
             functions_provider_url: "http://faas-swarm:8080/"
-            read_timeout:  "20s"   # set both here, and on your functions
-            write_timeout: "20s"   # set both here, and on your functions
+            read_timeout:  "25s"        # Maximum time to read HTTP request
+            write_timeout: "25s"        # Maximum time to write HTTP response
+            upstream_timeout: "20s"     # Maximum duration of upstream function call - should be more than read_timeout and write_timeout
             dnsrr: "true"  # Temporarily use dnsrr in place of VIP while issue persists on PWD
             faas_nats_address: "nats"
             faas_nats_port: 4222

--- a/gateway/handlers/alerthandler.go
+++ b/gateway/handlers/alerthandler.go
@@ -83,14 +83,14 @@ func scaleService(alert requests.PrometheusInnerAlert, service ServiceQuery) err
 	serviceName := alert.Labels.FunctionName
 
 	if len(serviceName) > 0 {
-		currentReplicas, maxReplicas, minReplicas, getErr := service.GetReplicas(serviceName)
+		queryResponse, getErr := service.GetReplicas(serviceName)
 		if getErr == nil {
 			status := alert.Status
 
-			newReplicas := CalculateReplicas(status, currentReplicas, uint64(maxReplicas), minReplicas)
+			newReplicas := CalculateReplicas(status, queryResponse.Replicas, uint64(queryResponse.MaxReplicas), queryResponse.MinReplicas)
 
-			log.Printf("[Scale] function=%s %d => %d.\n", serviceName, currentReplicas, newReplicas)
-			if newReplicas == currentReplicas {
+			log.Printf("[Scale] function=%s %d => %d.\n", serviceName, queryResponse.Replicas, newReplicas)
+			if newReplicas == queryResponse.Replicas {
 				return nil
 			}
 

--- a/gateway/handlers/forwarding_proxy.go
+++ b/gateway/handlers/forwarding_proxy.go
@@ -65,7 +65,8 @@ func forwardRequest(w http.ResponseWriter, r *http.Request, proxyClient *http.Cl
 		defer r.Body.Close()
 		upstreamReq.Body = r.Body
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout-time.Second*1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	res, resErr := proxyClient.Do(upstreamReq.WithContext(ctx))

--- a/gateway/handlers/service_query.go
+++ b/gateway/handlers/service_query.go
@@ -2,6 +2,14 @@ package handlers
 
 // ServiceQuery provides interface for replica querying/setting
 type ServiceQuery interface {
-	GetReplicas(service string) (currentReplicas uint64, maxReplicas uint64, minReplicas uint64, err error)
+	GetReplicas(service string) (response ServiceQueryResponse, err error)
 	SetReplicas(service string, count uint64) error
+}
+
+// ServiceQueryResponse response from querying a function status
+type ServiceQueryResponse struct {
+	Replicas          uint64
+	MaxReplicas       uint64
+	MinReplicas       uint64
+	AvailableReplicas uint64
 }

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -40,7 +40,7 @@ func main() {
 
 	servicePollInterval := time.Second * 5
 
-	reverseProxy := types.NewHTTPClientReverseProxy(config.FunctionsProviderURL, config.ReadTimeout)
+	reverseProxy := types.NewHTTPClientReverseProxy(config.FunctionsProviderURL, config.UpstreamTimeout)
 
 	faasHandlers.Proxy = internalHandlers.MakeForwardingProxyHandler(reverseProxy, &metricsOptions)
 	faasHandlers.RoutelessProxy = internalHandlers.MakeForwardingProxyHandler(reverseProxy, &metricsOptions)

--- a/gateway/types/proxy_client.go
+++ b/gateway/types/proxy_client.go
@@ -14,6 +14,7 @@ import (
 func NewHTTPClientReverseProxy(baseURL *url.URL, timeout time.Duration) *HTTPClientReverseProxy {
 	h := HTTPClientReverseProxy{
 		BaseURL: baseURL,
+		Timeout: timeout,
 	}
 
 	h.Client = &http.Client{
@@ -26,6 +27,7 @@ func NewHTTPClientReverseProxy(baseURL *url.URL, timeout time.Duration) *HTTPCli
 			IdleConnTimeout:       120 * time.Millisecond,
 			ExpectContinueTimeout: 1500 * time.Millisecond,
 		},
+		Timeout: timeout,
 	}
 	return &h
 }
@@ -34,4 +36,5 @@ func NewHTTPClientReverseProxy(baseURL *url.URL, timeout time.Duration) *HTTPCli
 type HTTPClientReverseProxy struct {
 	BaseURL *url.URL
 	Client  *http.Client
+	Timeout time.Duration
 }

--- a/gateway/types/readconfig.go
+++ b/gateway/types/readconfig.go
@@ -58,11 +58,11 @@ func (ReadConfig) Read(hasEnv HasEnv) GatewayConfig {
 		PrometheusPort: 9090,
 	}
 
-	readTimeout := parseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*8)
-	writeTimeout := parseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*8)
+	defaultDuration := time.Second * 8
 
-	cfg.ReadTimeout = readTimeout
-	cfg.WriteTimeout = writeTimeout
+	cfg.ReadTimeout = parseIntOrDurationValue(hasEnv.Getenv("read_timeout"), defaultDuration)
+	cfg.WriteTimeout = parseIntOrDurationValue(hasEnv.Getenv("write_timeout"), defaultDuration)
+	cfg.UpstreamTimeout = parseIntOrDurationValue(hasEnv.Getenv("upstream_timeout"), defaultDuration)
 
 	if len(hasEnv.Getenv("functions_provider_url")) > 0 {
 		var err error
@@ -113,6 +113,9 @@ type GatewayConfig struct {
 
 	// HTTP timeout for writing a response from functions.
 	WriteTimeout time.Duration
+
+	// UpstreamTimeout maximum duration of HTTP call to upstream URL
+	UpstreamTimeout time.Duration
 
 	// URL for alternate functions provider.
 	FunctionsProviderURL *url.URL


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use Go context to enforce upstream timeouts

## Motivation and Context

The upstream recently changed to use a http.Client in #552 - if the read/write timeout duration is exceeded then the client receives and empty response. This is as-designed in the Go stdlib but not all browsers understand how to handle that. This WIP change allows for a header to be sent back if the upstream call exceeds its timeout.

I also plan to introduce a new environmental variable `upstream_timeout` which would represent the maximum time for running a function in the back-end provider.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Docker Swarm + faas-swarm, Kubernetes + faas-netes 2.0

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.