### PR TITLE
Initial implementation for a graceful shutdown of the watchdog. 

### DIFF
--- a/watchdog/gracefull_shutdown_test.go
+++ b/watchdog/gracefull_shutdown_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net/http"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type server struct{}
+
+func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("This is a mock!"))
+}
+
+func simulateSIGTERM(pid int) {
+	time.Sleep(3 * time.Second)
+	syscall.Kill(pid, syscall.SIGTERM)
+}
+
+func Test_Should_Gracefully_Shutdown(t *testing.T) {
+	var pid int = syscall.Getpid()
+	successChan := make(chan bool, 1)
+
+	watchdog := &http.Server{Addr: ":8080", Handler: &server{}}
+	go gracefulShutdown(watchdog, successChan) // Method under test
+	go simulateSIGTERM(pid)
+
+	success := <-successChan
+
+	if !success {
+		t.Fail()
+	}
+}

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -5,15 +5,18 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/openfaas/faas/watchdog/types"
@@ -270,6 +273,38 @@ func makeRequestHandler(config *WatchdogConfig) func(http.ResponseWriter, *http.
 	}
 }
 
+// This method listens for incoming SIGTERM and starts an gracefully shutdown
+// successChan is indented for testing and should be nil in a normal environment
+func gracefulShutdown(server *http.Server, successChan chan bool) {
+	sigChannel := make(chan os.Signal, 1)
+	signal.Notify(sigChannel, syscall.SIGTERM) // For now supporting only linux is feasible
+
+	sig := <-sigChannel
+	log.Printf("Received Sig: %+v", sig)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := server.Shutdown(ctx); err != nil {
+		log.Printf("Error: %v during gracefully shutdown", err)
+
+		if successChan == nil {
+			os.Exit(1)
+		} else {
+			successChan <- false
+		}
+	} else {
+		signal.Stop(sigChannel)
+		log.Println("Gracefully stopped watchdog")
+
+		if successChan == nil {
+			os.Exit(0)
+		} else {
+			successChan <- true
+		}
+	}
+}
+
 func main() {
 	osEnv := types.OsEnv{}
 	readConfig := ReadConfig{}
@@ -303,5 +338,6 @@ func main() {
 		log.Println("Warning: \"suppress_lock\" is enabled. No automated health-checks will be in place for your function.")
 	}
 
+	go gracefulShutdown(s, nil)
 	log.Fatal(s.ListenAndServe())
 }


### PR DESCRIPTION
As discussed in #573 currently the watchdog does not react upon receiving a SIGTERM. I used the new functionality of the HTTP server to perform a graceful shutdown once a SIGTERM was received. As windows container are more rarely it currently only supports Linux container.

## Description
I created a new function named `gracefulShutdown ` which expects a pointer to an http server which will be used to perform the shutdown invocation. Further for testing purposes it also accepts a bool channel. However, I'm not quite happy with that trick, so if someone knows a better approach I'm happy to learn.

## Motivation and Context

- [x] I have raised an issue to propose this change #573 & openfaas/faas-netes#156

## How Has This Been Tested?
I created a simple test case which uses an HTTP Server to check if a received SIGTERM leads to a shutdown invocation on the HTTP Server.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
