### PR TITLE
Add feature for graceful shutdown of HTTP server

### DIFF
--- a/watchdog/requesthandler_test.go
+++ b/watchdog/requesthandler_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -361,11 +362,13 @@ func TestHandler_StatusOKForGETAndNoBody(t *testing.T) {
 	}
 }
 
-func TestHealthHandler_SatusOK_LockFilePresent(t *testing.T) {
+func TestHealthHandler_StatusOK_LockFilePresent(t *testing.T) {
 	rr := httptest.NewRecorder()
 
-	if lockFilePresent() == false {
-		if err := createLockFile(); err != nil {
+	present := lockFilePresent()
+
+	if present == false {
+		if _, err := createLockFile(); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -402,7 +405,7 @@ func TestHealthHandler_StatusInternalServerError_LockFileNotPresent(t *testing.T
 
 	required := http.StatusInternalServerError
 	if status := rr.Code; status != required {
-		t.Errorf("handler retruned wrong status code: got %v, but wanted %v", status, required)
+		t.Errorf("handler returned wrong status code - got: %v, want: %v", status, required)
 	}
 }
 
@@ -425,4 +428,11 @@ func TestHealthHandler_SatusMethoNotAllowed_ForWriteableVerbs(t *testing.T) {
 			t.Errorf("handler returned wrong status code: got %v, but wanted %v", status, required)
 		}
 	}
+}
+
+func removeLockFile() error {
+	path := filepath.Join(os.TempDir(), ".lock")
+	log.Printf("Removing lock-file : %s\n", path)
+	removeErr := os.Remove(path)
+	return removeErr
 }


### PR DESCRIPTION
    Add feature for graceful shutdown of HTTP server

    If the watchdog is sent SIGTERM from an external process then it
    should stop accepting new connections and attempt to finish the
    work in progress. This change makes use of the new ability in Go
    1.9 and onwards to cancel a HTTP server gracefully.

    The write_timeout duration is used as a grace period to allow all
    in-flight requests to complete. The pattern is taken directly from
    the offical example in the Golang documentation. [1]

    Further tuning and testing may be needed for Windows containers which
    have a different set of signals for closing work. This change aims
    to cover the majority use-case for Linux containers.

    The HTTP health-check is also invalidated by creating an and
    expression with the existing lock file.

    Tested with Kubernetes by deploying a custom watchdog and the
    fprocess of `env`. Log message was observed when scaling down and
    connections stopped being accepted on terminating replica.

    Also corrects some typos from previous PR.

    [1] https://golang.org/pkg/net/http/#Server.Shutdown

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#573 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests and with a load-test via `hey` testing tool with concurrent requests. When I sent sigint via `kill` the process stayed open until the write_timeout duration had completed but didn't accept any new work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
