### PR TITLE
Refactoring suggestion: Use http package consts for http methods

### DIFF
--- a/gateway/handlers/cors.go
+++ b/gateway/handlers/cors.go
@@ -11,7 +11,7 @@ type CORSHandler struct {
 func (c CORSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// https://raw.githubusercontent.com/openfaas/store/master/store.json
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-	w.Header().Set("Access-Control-Allow-Methods", "GET")
+	w.Header().Set("Access-Control-Allow-Methods", http.MethodGet)
 	w.Header().Set("Access-Control-Allow-Origin", c.AllowedHost)
 
 	(*c.Upstream).ServeHTTP(w, r)

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -85,15 +85,15 @@ func main() {
 
 	r.HandleFunc("/system/alert", faasHandlers.Alert)
 
-	r.HandleFunc("/system/function/{name:[-a-zA-Z_0-9]+}", queryFunction).Methods("GET")
-	r.HandleFunc("/system/functions", listFunctions).Methods("GET")
-	r.HandleFunc("/system/functions", faasHandlers.DeployFunction).Methods("POST")
-	r.HandleFunc("/system/functions", faasHandlers.DeleteFunction).Methods("DELETE")
-	r.HandleFunc("/system/functions", faasHandlers.UpdateFunction).Methods("PUT")
+	r.HandleFunc("/system/function/{name:[-a-zA-Z_0-9]+}", queryFunction).Methods(http.MethodGet)
+	r.HandleFunc("/system/functions", listFunctions).Methods(http.MethodGet)
+	r.HandleFunc("/system/functions", faasHandlers.DeployFunction).Methods(http.MethodPost)
+	r.HandleFunc("/system/functions", faasHandlers.DeleteFunction).Methods(http.MethodDelete)
+	r.HandleFunc("/system/functions", faasHandlers.UpdateFunction).Methods(http.MethodPut)
 
 	if faasHandlers.QueuedProxy != nil {
-		r.HandleFunc("/async-function/{name:[-a-zA-Z_0-9]+}/", faasHandlers.QueuedProxy).Methods("POST")
-		r.HandleFunc("/async-function/{name:[-a-zA-Z_0-9]+}", faasHandlers.QueuedProxy).Methods("POST")
+		r.HandleFunc("/async-function/{name:[-a-zA-Z_0-9]+}/", faasHandlers.QueuedProxy).Methods(http.MethodPost)
+		r.HandleFunc("/async-function/{name:[-a-zA-Z_0-9]+}", faasHandlers.QueuedProxy).Methods(http.MethodPost)
 
 		r.HandleFunc("/system/async-report", faasHandlers.AsyncReport)
 	}
@@ -104,13 +104,13 @@ func main() {
 	allowedCORSHost := "raw.githubusercontent.com"
 	fsCORS := handlers.DecorateWithCORS(fs, allowedCORSHost)
 
-	r.PathPrefix("/ui/").Handler(http.StripPrefix("/ui", fsCORS)).Methods("GET")
+	r.PathPrefix("/ui/").Handler(http.StripPrefix("/ui", fsCORS)).Methods(http.MethodGet)
 
-	r.HandleFunc("/", faasHandlers.RoutelessProxy).Methods("POST")
+	r.HandleFunc("/", faasHandlers.RoutelessProxy).Methods(http.MethodPost)
 
 	metricsHandler := metrics.PrometheusHandler()
 	r.Handle("/metrics", metricsHandler)
-	r.Handle("/", http.RedirectHandler("/ui/", http.StatusMovedPermanently)).Methods("GET")
+	r.Handle("/", http.RedirectHandler("/ui/", http.StatusMovedPermanently)).Methods(http.MethodGet)
 
 	tcpPort := 8080
 

--- a/gateway/tests/cors_test.go
+++ b/gateway/tests/cors_test.go
@@ -29,8 +29,8 @@ func Test_HeadersAdded(t *testing.T) {
 	}
 
 	actualMethods := rr.Header().Get("Access-Control-Allow-Methods")
-	if actualMethods != "GET" {
-		t.Errorf("Access-Control-Allow-Methods: want: %s got: %s", "GET", actualMethods)
+	if actualMethods != http.MethodGet {
+		t.Errorf("Access-Control-Allow-Methods: want: %s got: %s", http.MethodGet, actualMethods)
 	}
 
 }

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -277,7 +277,7 @@ func removeLockFile() error {
 func makeHealthHandler() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
-		case "GET":
+		case http.MethodGet:
 			if lockFilePresent() == false {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
@@ -298,11 +298,11 @@ func makeRequestHandler(config *WatchdogConfig) func(http.ResponseWriter, *http.
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case
-			"POST",
-			"PUT",
-			"DELETE",
+			http.MethodPost,
+			http.MethodPut,
+			http.MethodDelete,
 			"UPDATE",
-			"GET":
+			http.MethodGet:
 			pipeRequest(config, w, r, r.Method)
 			break
 		default:

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -301,7 +301,6 @@ func makeRequestHandler(config *WatchdogConfig) func(http.ResponseWriter, *http.
 			http.MethodPost,
 			http.MethodPut,
 			http.MethodDelete,
-			"UPDATE",
 			http.MethodGet:
 			pipeRequest(config, w, r, r.Method)
 			break

--- a/watchdog/requesthandler_test.go
+++ b/watchdog/requesthandler_test.go
@@ -29,7 +29,7 @@ func TestHandler_HasCustomHeaderInFunction_WithCgi_Mode(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	body := ""
-	req, err := http.NewRequest("POST", "/", bytes.NewBufferString(body))
+	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
 	req.Header.Add("custom-header", "value")
 
 	if err != nil {
@@ -68,7 +68,7 @@ func TestHandler_HasCustomHeaderInFunction_WithCgiMode_AndBody(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	body := "test"
-	req, err := http.NewRequest("POST", "/", bytes.NewBufferString(body))
+	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
 	req.Header.Add("custom-header", "value")
 
 	if err != nil {
@@ -110,7 +110,7 @@ func TestHandler_StderrWritesToStderr_CombinedOutput_False(t *testing.T) {
 	log.SetOutput(b)
 
 	body := ""
-	req, err := http.NewRequest("POST", "/", bytes.NewBufferString(body))
+	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
 
 	if err != nil {
 		t.Fatal(err)
@@ -151,7 +151,7 @@ func TestHandler_StderrWritesToResponse_CombinedOutput_True(t *testing.T) {
 	log.SetOutput(b)
 
 	body := ""
-	req, err := http.NewRequest("POST", "/", bytes.NewBufferString(body))
+	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
 
 	if err != nil {
 		t.Fatal(err)
@@ -200,7 +200,7 @@ func TestHandler_DoesntHaveCustomHeaderInFunction_WithoutCgi_Mode(t *testing.T) 
 	rr := httptest.NewRecorder()
 
 	body := ""
-	req, err := http.NewRequest("POST", "/", bytes.NewBufferString(body))
+	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
 	req.Header.Add("custom-header", "value")
 	if err != nil {
 		t.Fatal(err)
@@ -236,7 +236,7 @@ func TestHandler_HasXDurationSecondsHeader(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	body := "hello"
-	req, err := http.NewRequest("POST", "/", bytes.NewBufferString(body))
+	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -262,7 +262,7 @@ func TestHandler_HasXDurationSecondsHeader(t *testing.T) {
 func TestHandler_RequestTimeoutFailsForExceededDuration(t *testing.T) {
 	rr := httptest.NewRecorder()
 
-	verbs := []string{"POST"}
+	verbs := []string{http.MethodPost}
 	for _, verb := range verbs {
 
 		body := "hello"
@@ -290,7 +290,7 @@ func TestHandler_RequestTimeoutFailsForExceededDuration(t *testing.T) {
 func TestHandler_StatusOKAllowed_ForWriteableVerbs(t *testing.T) {
 	rr := httptest.NewRecorder()
 
-	verbs := []string{"POST", "PUT", "UPDATE", "DELETE"}
+	verbs := []string{http.MethodPost, http.MethodPut, "UPDATE", http.MethodDelete}
 	for _, verb := range verbs {
 
 		body := "hello"
@@ -341,7 +341,7 @@ func TestHandler_StatusMethodNotAllowed_ForUnknown(t *testing.T) {
 func TestHandler_StatusOKForGETAndNoBody(t *testing.T) {
 	rr := httptest.NewRecorder()
 
-	req, err := http.NewRequest("GET", "/", nil)
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -370,7 +370,7 @@ func TestHealthHandler_SatusOK_LockFilePresent(t *testing.T) {
 		}
 	}
 
-	req, err := http.NewRequest("GET", "/_/health", nil)
+	req, err := http.NewRequest(http.MethodGet, "/_/health", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -393,7 +393,7 @@ func TestHealthHandler_StatusInternalServerError_LockFileNotPresent(t *testing.T
 		}
 	}
 
-	req, err := http.NewRequest("GET", "/_/health", nil)
+	req, err := http.NewRequest(http.MethodGet, "/_/health", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,7 +409,7 @@ func TestHealthHandler_StatusInternalServerError_LockFileNotPresent(t *testing.T
 func TestHealthHandler_SatusMethoNotAllowed_ForWriteableVerbs(t *testing.T) {
 	rr := httptest.NewRecorder()
 
-	verbs := []string{"POST", "PUT", "UPDATE", "DELETE"}
+	verbs := []string{http.MethodPost, http.MethodPut, "UPDATE", http.MethodDelete}
 
 	for _, verb := range verbs {
 		req, err := http.NewRequest(verb, "/_/health", nil)

--- a/watchdog/requesthandler_test.go
+++ b/watchdog/requesthandler_test.go
@@ -290,7 +290,7 @@ func TestHandler_RequestTimeoutFailsForExceededDuration(t *testing.T) {
 func TestHandler_StatusOKAllowed_ForWriteableVerbs(t *testing.T) {
 	rr := httptest.NewRecorder()
 
-	verbs := []string{http.MethodPost, http.MethodPut, "UPDATE", http.MethodDelete}
+	verbs := []string{http.MethodPost, http.MethodPut, http.MethodDelete}
 	for _, verb := range verbs {
 
 		body := "hello"
@@ -409,7 +409,7 @@ func TestHealthHandler_StatusInternalServerError_LockFileNotPresent(t *testing.T
 func TestHealthHandler_SatusMethoNotAllowed_ForWriteableVerbs(t *testing.T) {
 	rr := httptest.NewRecorder()
 
-	verbs := []string{http.MethodPost, http.MethodPut, "UPDATE", http.MethodDelete}
+	verbs := []string{http.MethodPost, http.MethodPut, http.MethodDelete}
 
 	for _, verb := range verbs {
 		req, err := http.NewRequest(verb, "/_/health", nil)


### PR DESCRIPTION
## Description

This commit replaces occurences of http method strings with the corresponding consts from the http package.

*Note* `UPDATE` is not strictly speaking a valid method and as such isn't part of the http package so these occurrences have not been altered (should be a `PUT` or `PATCH`?)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change - skipped due to trivial nature of the change

Motivation is to avoid the use of magic strings in code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified that existing test suite results are identical to those prior to the change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
