### PR TITLE
Fix bug reading default value for combine_output

### DIFF
--- a/watchdog/Dockerfile
+++ b/watchdog/Dockerfile
@@ -2,11 +2,10 @@ FROM golang:1.8.5
 RUN mkdir -p /go/src/github.com/openfaas/faas/watchdog
 WORKDIR /go/src/github.com/openfaas/faas/watchdog
 
-COPY main.go        .
-COPY readconfig.go  .
-COPY config_test.go .
+COPY main.go            .
+COPY readconfig.go      .
+COPY readconfig_test.go .
 COPY requesthandler_test.go .
-
 COPY types types
 
 # Run a gofmt and exclude all vendored code.

--- a/watchdog/readconfig.go
+++ b/watchdog/readconfig.go
@@ -87,7 +87,7 @@ func (ReadConfig) Read(hasEnv HasEnv) WatchdogConfig {
 
 	cfg.contentType = hasEnv.Getenv("content_type")
 
-	if isBoolValueSet("combine_output") {
+	if isBoolValueSet(hasEnv.Getenv("combine_output")) {
 		cfg.combineOutput = parseBoolValue(hasEnv.Getenv("combine_output"))
 	}
 

--- a/watchdog/readconfig_test.go
+++ b/watchdog/readconfig_test.go
@@ -26,6 +26,31 @@ func (e EnvBucket) Setenv(key string, value string) {
 	e.Items[key] = value
 }
 
+func TestRead_CombineOutput_DefaultTrue(t *testing.T) {
+	defaults := NewEnvBucket()
+	readConfig := ReadConfig{}
+
+	config := readConfig.Read(defaults)
+	want := true
+	if config.combineOutput != want {
+		t.Logf("combineOutput error, want: %v, got: %v", want, config.combineOutput)
+		t.Fail()
+	}
+}
+
+func TestRead_CombineOutput_OverrideFalse(t *testing.T) {
+	defaults := NewEnvBucket()
+	readConfig := ReadConfig{}
+	defaults.Setenv("combine_output", "false")
+
+	config := readConfig.Read(defaults)
+	want := false
+	if config.combineOutput != want {
+		t.Logf("combineOutput error, want: %v, got: %v", want, config.combineOutput)
+		t.Fail()
+	}
+}
+
 func TestRead_CgiHeaders_OverrideFalse(t *testing.T) {
 	defaults := NewEnvBucket()
 	readConfig := ReadConfig{}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

The default should be set to true so we maintain backwards.
compatibility. readconfig.go was altered due to bug reading default value. 

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

## Motivation and Context

Issue spotted by Ivana @iyovcheva 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This was tested by adding unit tests to readconfig_test.go for positive and
negative scenarios.

Also built a local watchdog and checked default behavior was fixed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.