### PR TITLE
guide,do: switch to ubuntu-17-10-x64

### DIFF
--- a/guide/deployment_digitalocean.md
+++ b/guide/deployment_digitalocean.md
@@ -33,7 +33,7 @@ This process will take a few minutes as Droplets are created and Docker installe
 for i in 1 2 3; do
     docker-machine create \
         --driver digitalocean \
-        --digitalocean-image ubuntu-17-04-x64 \
+        --digitalocean-image ubuntu-17-10-x64 \
         --digitalocean-tags openfaas-getting-started \
         --digitalocean-region=nyc3 \
         --digitalocean-access-token $DOTOKEN \


### PR DESCRIPTION
Signed-off-by: Marko Mudrinić <mudrinic.mare@gmail.com>

## Description
This PR updated DigitalOcean Deployment guide to use Ubuntu 17.10 instead of 17.04.
17.04 is not available anymore on DigitalOcean, so `docker-machine` returns the following error:
```
Creating machine...
(node-1) Creating SSH key...
(node-1) Creating Digital Ocean droplet...
Error creating machine: Error in driver during machine creation: POST https://api.digitalocean.com/v2/droplets: 422 You specified an invalid image for Droplet creation.
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
