### PR TITLE
[Merge] Implemented the autoscaling steps to be proportions of the max replicas.

### DIFF
--- a/gateway/handlers/alerthandler_test.go
+++ b/gateway/handlers/alerthandler_test.go
@@ -7,45 +7,80 @@ import (
 	"testing"
 )
 
-func TestScale1to5(t *testing.T) {
+func TestDisabledScale(t *testing.T) {
 	minReplicas := uint64(1)
-	newReplicas := CalculateReplicas("firing", 1, DefaultMaxReplicas, minReplicas)
-	if newReplicas != 5 {
-		t.Log("Expected increment in blocks of 5 from 1 to 5")
+	scalingFactor := uint64(0)
+	newReplicas := CalculateReplicas("firing", DefaultMinReplicas, DefaultMaxReplicas, minReplicas, scalingFactor)
+	if newReplicas != 0 {
+		t.Log("Expected not to scale")
 		t.Fail()
 	}
 }
 
-func TestScale5to10(t *testing.T) {
-	minReplicas := uint64(1)
-	newReplicas := CalculateReplicas("firing", 5, DefaultMaxReplicas, minReplicas)
-	if newReplicas != 10 {
-		t.Log("Expected increment in blocks of 5 from 5 to 10")
+func TestParameterEdge(t *testing.T){
+	minReplicas := uint64(0)
+	scalingFactor := uint64(0)
+	newReplicas := CalculateReplicas("firing", DefaultMinReplicas, DefaultMaxReplicas, minReplicas, scalingFactor)
+	if newReplicas != 0 {
+		t.Log("Expected not to scale")
 		t.Fail()
 	}
 }
 
-func TestScaleCeilingOf20Replicas_Noaction(t *testing.T) {
+func TestMaxScale(t *testing.T){
 	minReplicas := uint64(1)
-	newReplicas := CalculateReplicas("firing", 20, DefaultMaxReplicas, minReplicas)
+	scalingFactor := uint64(100)
+	newReplicas := CalculateReplicas("firing", DefaultMinReplicas, DefaultMaxReplicas, minReplicas, scalingFactor)
 	if newReplicas != 20 {
 		t.Log("Expected ceiling of 20 replicas")
 		t.Fail()
 	}
 }
 
-func TestScaleCeilingOf20Replicas(t *testing.T) {
+func TestInitialScale(t *testing.T) {
 	minReplicas := uint64(1)
-	newReplicas := CalculateReplicas("firing", 19, DefaultMaxReplicas, minReplicas)
+	scalingFactor := uint64(20)
+	newReplicas := CalculateReplicas("firing", DefaultMinReplicas, DefaultMaxReplicas, minReplicas, scalingFactor)
+	if newReplicas != 4 {
+		t.Log("Expected the increment to equal 4")
+		t.Fail()
+	}
+}
+
+func TestScale(t *testing.T) {
+	minReplicas := uint64(1)
+	scalingFactor := uint64(20)
+	newReplicas := CalculateReplicas("firing", 4, DefaultMaxReplicas, minReplicas, scalingFactor)
+	if newReplicas != 8 {
+		t.Log("Expected newReplicas to equal 8")
+		t.Fail()
+	}
+}
+
+func TestScaleCeiling(t *testing.T) {
+	minReplicas := uint64(1)
+	scalingFactor := uint64(20)
+	newReplicas := CalculateReplicas("firing", 20, DefaultMaxReplicas, minReplicas, scalingFactor)
 	if newReplicas != 20 {
 		t.Log("Expected ceiling of 20 replicas")
 		t.Fail()
 	}
 }
 
-func TestBackingOff10to1(t *testing.T) {
+func TestScaleCeilingEdge(t *testing.T) {
 	minReplicas := uint64(1)
-	newReplicas := CalculateReplicas("resolved", 10, DefaultMaxReplicas, minReplicas)
+	scalingFactor := uint64(20)
+	newReplicas := CalculateReplicas("firing", 19, DefaultMaxReplicas, minReplicas, scalingFactor)
+	if newReplicas != 20 {
+		t.Log("Expected ceiling of 20 replicas")
+		t.Fail()
+	}
+}
+
+func TestBackingOff(t *testing.T) {
+	minReplicas := uint64(1)
+	scalingFactor := uint64(20)
+	newReplicas := CalculateReplicas("resolved", 8, DefaultMaxReplicas, minReplicas, scalingFactor)
 	if newReplicas != 1 {
 		t.Log("Expected backing off to 1 replica")
 		t.Fail()

--- a/gateway/handlers/service_query.go
+++ b/gateway/handlers/service_query.go
@@ -11,5 +11,6 @@ type ServiceQueryResponse struct {
 	Replicas          uint64
 	MaxReplicas       uint64
 	MinReplicas       uint64
+	ScalingFactor 	  uint64
 	AvailableReplicas uint64
 }

--- a/gateway/plugin/external.go
+++ b/gateway/plugin/external.go
@@ -95,12 +95,12 @@ func (s ExternalServiceQuery) GetReplicas(serviceName string) (handlers.ServiceQ
 
 		minReplicas = extractLabelValue(labels[handlers.MinScaleLabel], minReplicas)
 		maxReplicas = extractLabelValue(labels[handlers.MaxScaleLabel], maxReplicas)
-		temp := extractLabelValue(labels[handlers.ScalingFactorLabel], scalingFactor)
+		extractedScalingFactor := extractLabelValue(labels[handlers.ScalingFactorLabel], scalingFactor)
 
-		if temp >= 0 && temp <= 100 {
-			scalingFactor = temp
+		if extractedScalingFactor >= 0 && extractedScalingFactor <= 100 {
+			scalingFactor = extractedScalingFactor
 		} else {
-			log.Printf("Bad Scaling Factor: %d, is in range [0 - 100]", temp)
+			log.Printf("Bad Scaling Factor: %d, is not in range of [0 - 100]. Will fallback to %d", extractedScalingFactor, scalingFactor)
 		}
 	}
 
@@ -147,8 +147,8 @@ func (s ExternalServiceQuery) SetReplicas(serviceName string, count uint64) erro
 	return err
 }
 
-// This methods tries to parse the provided raw label value and if it fails
-// it will return the provided fallback value and log and message
+// extractLabelValue will parse the provided raw label value and if it fails
+// it will return the provided fallback value and log an message
 func extractLabelValue(rawLabelValue string, fallback uint64 ) uint64{
 	if len(rawLabelValue) <= 0 {
 		return fallback

--- a/gateway/plugin/external_test.go
+++ b/gateway/plugin/external_test.go
@@ -1,0 +1,32 @@
+package plugin
+
+import "testing"
+
+const fallbackValue = 120
+
+func TestLabelValueWasEmpty(t *testing.T) {
+	extractedValue := extractLabelValue("", fallbackValue)
+
+	if extractedValue != fallbackValue {
+		t.Log("Expected extractedValue to equal the fallbackValue")
+		t.Fail()
+	}
+}
+
+func TestLabelValueWasValid(t *testing.T) {
+	extractedValue := extractLabelValue("42", fallbackValue)
+
+	if extractedValue != 42 {
+		t.Log("Expected extractedValue to equal answer to life (42)")
+		t.Fail()
+	}
+}
+
+func TestLabelValueWasInValid(t *testing.T) {
+	extractedValue := extractLabelValue("InvalidValue", fallbackValue)
+
+	if extractedValue != fallbackValue {
+		t.Log("Expected extractedValue to equal the fallbackValue")
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Implemented the proportional autoscaling steps based on the maxReplicas as described in #569. Additionally, I added support for a label `com.openfaas.scale.factor` which allows configuring the proportion, setting it to 0 even allows to disable autoscaling. 

Signed-off-by: Simon Pelczer <templum.dev@gmail.com>

## Description
I updated the signature for `CalculateReplicas` to also take in `scalingFactor uint64` which will be used to calculate the scaling step. This value can be set using a label `com.openfaas.scale.factor`, which also can be used to disable auto-scaling (by setting it to zero). I updated the existing tests for `alerthandler.go` to reflect the done changes. Additionally, I created a dedicated test for the disable functionality when setting `scalingFactor = 0 `.

## Motivation and Context
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
-  #569 

## How Has This Been Tested?
- Executed all of the tests located within the gateway

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. [See here](https://github.com/openfaas/docs/pull/5)
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
