### PR TITLE
CI: update Travis to use Go 1.9 for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 sudo: required
 
+language: go
+go:
+  - "1.9"
+
 services:
       - docker
+
 addons:
   apt:
     packages:
@@ -13,12 +18,14 @@ script:
     - sh build.sh
     # Invoke ci script too
     - sh contrib/ci.sh
+
 after_success:
     - if [ ! -s "$TRAVIS_TAG" ] ; then 
         docker tag $DOCKER_NS/gateway:latest-dev $DOCKER_NS/gateway:$TRAVIS_TAG;
         docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD;
         docker push $DOCKER_NS/gateway:$TRAVIS_TAG;
         fi
+
 deploy:
   provider: releases
   api_key:

--- a/contrib/ci.sh
+++ b/contrib/ci.sh
@@ -3,6 +3,20 @@
 docker swarm init --advertise-addr=127.0.0.1
 
 ./deploy_stack.sh
+docker service update func_gateway --image=functions/gateway:latest-dev
+
+# Script makes sure OpenFaaS API gateway is ready before running tests
+
+for i in {1..30};
+do
+  echo "Checking if 127.0.0.1:8000 is up.. ${i}/30" 
+  curl -fs 127.0.0.1:8080/
+
+  if [ $? -eq 0 ]; then
+    break
+  fi
+  sleep 0.5
+done
 
 cd ..
 
@@ -11,14 +25,14 @@ echo $GOPATH
 mkdir -p $GOPATH/src/github.com/openfaas/
 cp -r faas $GOPATH/src/github.com/openfaas/
 
-git clone https://github.com/openfaas/certify-incubator
+git clone https://github.com/openfaas/certifier
 
-cp -r certify-incubator $GOPATH/src/github.com/openfaas/
+cp -r certifier $GOPATH/src/github.com/openfaas/
 
 cd $GOPATH/src/github.com/openfaas/faas/gateway/tests/integration && \
    go test -v
 
-cd $GOPATH/src/github.com/openfaas/certify-incubator && \
+cd $GOPATH/src/github.com/openfaas/certifier && \
    make test
 
 exit 0

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:1.9.4 as build
+
 RUN curl -sL https://github.com/alexellis/license-check/releases/download/0.2.2/license-check \
       > /usr/bin/license-check \
       && chmod +x /usr/bin/license-check

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -115,8 +115,6 @@ func main() {
 
 	r.PathPrefix("/ui/").Handler(http.StripPrefix("/ui", fsCORS)).Methods(http.MethodGet)
 
-	r.HandleFunc("/", faasHandlers.RoutelessProxy).Methods(http.MethodPost)
-
 	metricsHandler := metrics.PrometheusHandler()
 	r.Handle("/metrics", metricsHandler)
 	r.Handle("/", http.RedirectHandler("/ui/", http.StatusMovedPermanently)).Methods(http.MethodGet)

--- a/gateway/tests/integration/routes_test.go
+++ b/gateway/tests/integration/routes_test.go
@@ -100,23 +100,23 @@ func TestEchoIt_Post_Route_Handler(t *testing.T) {
 	}
 }
 
-func TestEchoIt_Post_X_Header_Routing_Handler(t *testing.T) {
-	reqBody := "test message"
-	headers := make(map[string]string, 0)
-	headers["X-Function"] = "func_echoit"
+// Test suppressed due to X-Header deprecation.
+// func TestEchoIt_Post_X_Header_Routing_Handler(t *testing.T) {
+// 	reqBody := "test message"
+// 	headers := make(map[string]string, 0)
+// 	headers["X-Function"] = "func_echoit"
 
-	body, code, err := fireRequestWithHeaders("http://localhost:8080/", http.MethodPost, reqBody, headers)
+// 	body, code, err := fireRequestWithHeaders("http://localhost:8080/", http.MethodPost, reqBody, headers)
 
-	if err != nil {
-		t.Log(err)
-		t.Fail()
-	}
-	if code != http.StatusOK {
-		t.Log("Failed")
-	}
-	if body != reqBody {
-		t.Log("Expected body returned")
-		t.Fail()
-	}
-
-}
+// 	if err != nil {
+// 		t.Log(err)
+// 		t.Fail()
+// 	}
+// 	if code != http.StatusOK {
+// 		t.Logf("statusCode - want: %d, got: %d", http.StatusOK, code)
+// 	}
+// 	if body != reqBody {
+// 		t.Logf("Expected body from echo function to be equal to input, but was: %s", body)
+// 		t.Fail()
+// 	}
+// }

--- a/gateway/tests/integration/routes_test.go
+++ b/gateway/tests/integration/routes_test.go
@@ -49,7 +49,8 @@ func fireRequestWithHeaders(url string, method string, reqBody string, headers m
 
 func TestGet_Rejected(t *testing.T) {
 	var reqBody string
-	_, code, err := fireRequest("http://localhost:8080/function/func_echoit", http.MethodGet, reqBody)
+	unsupportedMethod := http.MethodHead
+	_, code, err := fireRequest("http://localhost:8080/function/func_echoit", unsupportedMethod, reqBody)
 	want := http.StatusMethodNotAllowed
 	if code != want {
 		t.Logf("Failed got: %d, wanted: %d", code, want)

--- a/watchdog/Dockerfile
+++ b/watchdog/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.8.5
+FROM golang:1.9.4 as build
+
 RUN mkdir -p /go/src/github.com/openfaas/faas/watchdog
 WORKDIR /go/src/github.com/openfaas/faas/watchdog
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Get is a supported method so this test failed, I've now changed
this to an unsupported method - i.e. HEAD to trigger the error
and keep the test.

Deprecates routeless proxy and related test. 

Changes to the tests also ensure that the built version of the gateway is deployed
for testing rather than the latest release.

## Motivation and Context

Integration tests and the certifier have not been running correctly for some time. This enables them to run.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Via Travis CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.