### PR TITLE
On funcstore error, change to manual tab

### DIFF
--- a/gateway/assets/script/bootstrap.js
+++ b/gateway/assets/script/bootstrap.js
@@ -6,7 +6,10 @@ var app = angular.module('faasGateway', ['ngMaterial', 'faasGateway.funcStore'])
 
 app.controller("home", ['$scope', '$log', '$http', '$location', '$interval', '$filter', '$mdDialog', '$mdToast', '$mdSidenav',
     function($scope, $log, $http, $location, $interval, $filter, $mdDialog, $mdToast, $mdSidenav) {
-        var newFuncTabIdx = 0;
+        var FUNCSTORE_DEPLOY_TAB_INDEX = 0;
+        var MANUAL_DEPLOY_TAB_INDEX = 1;
+
+        var newFuncTabIdx = FUNCSTORE_DEPLOY_TAB_INDEX;
         $scope.functions = [];
         $scope.invocationInProgress = false;
         $scope.invocationRequest = "";
@@ -274,6 +277,8 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$interval', '$f
                         $scope.closeDialog();
                         showPostInvokedToast("Function created");
                     }).catch(function(error1) {
+                        showPostInvokedToast("Error");
+                        $scope.selectedTabIdx = MANUAL_DEPLOY_TAB_INDEX;
                         $scope.validationError = error1.data;
                     });
             };


### PR DESCRIPTION
Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
Fixed the UI so that when an error occurs, the tab automatically changes
to the manual tab in order to show the errors.

## Description
<!--- Describe your changes in detail -->
When an error occurs on the function store deployment, the tab will switch to the Manual Deploy tab. Hence, showing what error occurred.
![faas_error_switch](https://user-images.githubusercontent.com/3941889/38311619-9a9540c2-385a-11e8-86fe-14012888b7d1.gif)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Issue #481 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Deploy a function from store
2. Try to deploy the same function from store
3. Confirm that the tab switches to the manual deploy tab and shows the error.

Tested Browsers:
* Chrome
* Safari
* Firefox
* IE11
* Edge

Regression Tests:
* Deploy, Invoke, Delete a function
  * figlet
  * qr-code

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
