### PR TITLE
Fix apikey-secret README.md

### DIFF
--- a/sample-functions/apikey-secret/README.md
+++ b/sample-functions/apikey-secret/README.md
@@ -2,7 +2,7 @@
 
 This function returns access denied, or unlocked depending on whether your header for X-Api-Key matches a secret in the cluster called `secret_api_key`.
 
-See the [secure secret management guide](../guide/secure_secret_management.md) for more information on secrets.
+See the [secure secret management guide](../../guide/secure_secret_management.md) for more information on secrets.
 
 ## Trying the sample:
 
@@ -11,7 +11,7 @@ See the [secure secret management guide](../guide/secure_secret_management.md) f
 $ docker secret remove secret_api_key  # make sure we delete any existing secret
 
 # Create a secret with Swarm
-$ echo "secret_value_goes_here" | docker secret create secret_api_key
+$ echo -n "secret_value_goes_here" | docker secret create secret_api_key -
 
 # Deploy this sample with Docker Swarm and attach the secret to it
 


### PR DESCRIPTION
Following the existing README instructions would result in an error
when the user attempted to create the secret.  This small change
remediates the instruction so that the secret is successfully created.

Signed-off-by: rgee0 <richard@technologee.co.uk>

## Description
The secret would previously fail to create.  This change corrects that.

## Motivation and Context
- [x] I have raised an issue to propose this change (This is referenced in #635) 


## How Has This Been Tested?
Ran through the steps and confirmed as working

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
