### PR TITLE
[WIP] Added -version flag to watchdog

### DIFF
--- a/watchdog/Dockerfile
+++ b/watchdog/Dockerfile
@@ -1,4 +1,6 @@
 FROM golang:1.9.4 as build
+ARG VERSION
+ARG GIT_COMMIT
 
 RUN mkdir -p /go/src/github.com/openfaas/faas/watchdog
 WORKDIR /go/src/github.com/openfaas/faas/watchdog
@@ -8,14 +10,26 @@ COPY readconfig.go      .
 COPY readconfig_test.go .
 COPY requesthandler_test.go .
 COPY types types
+COPY version.go .
 
 # Run a gofmt and exclude all vendored code.
 RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"
 
 RUN go test -v ./...
-
 # Stripping via -ldflags "-s -w" 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w" -installsuffix cgo -o watchdog . \
-    && GOARM=7 GOARCH=arm CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w" -installsuffix cgo -o watchdog-armhf . \
-    && GOARCH=arm64 CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w" -installsuffix cgo -o watchdog-arm64 . \
-    && GOOS=windows CGO_ENABLED=0 go build -a -ldflags "-s -w" -installsuffix cgo -o watchdog.exe .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w \
+        -X main.GitCommit=$GIT_COMMIT \
+        -X main.Version=$VERSION" \
+        -installsuffix cgo -o watchdog . \
+    && GOARM=7 GOARCH=arm CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w \ 
+        -X main.GitCommit=$GIT_COMMIT \
+        -X main.Version=$VERSION" \
+        -installsuffix cgo -o watchdog-armhf . \
+    && GOARCH=arm64 CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w \ 
+        -X main.GitCommit=$GIT_COMMIT \
+        -X main.Version=$VERSION" \ 
+        -installsuffix cgo -o watchdog-arm64 . \
+    && GOOS=windows CGO_ENABLED=0 go build -a -ldflags "-s -w \
+        -X main.GitCommit=$GIT_COMMIT \
+        -X main.Version=$VERSION" \ 
+        -installsuffix cgo -o watchdog.exe .

--- a/watchdog/build.sh
+++ b/watchdog/build.sh
@@ -7,11 +7,17 @@ if [ "$arch" = "armv7l" ] ; then
     exit 1
 fi
 
+cd ..
+GIT_COMMIT=$(git rev-list -1 HEAD)
+VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///')
+cd watchdog
+
 if [ ! $http_proxy == "" ] 
 then
-    docker build --no-cache --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -t functions/watchdog:build .
+    docker build --no-cache --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy \
+        --build-arg GIT_COMMIT=$GIT_COMMIT --build-arg VERSION=$VERSION -t functions/watchdog:build .
 else
-    docker build -t functions/watchdog:build .
+    docker build --no-cache --build-arg VERSION=$VERSION --build-arg GIT_COMMIT=$GIT_COMMIT -t functions/watchdog:build .
 fi
 
 docker create --name buildoutput functions/watchdog:build echo

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -309,7 +310,12 @@ func makeRequestHandler(config *WatchdogConfig) func(http.ResponseWriter, *http.
 	}
 }
 
+var (
+	version = flag.Bool("version", false, "Print the version and Git SHA")
+)
+
 func main() {
+	flag.Parse()
 	acceptingConnections = false
 
 	osEnv := types.OsEnv{}
@@ -318,6 +324,12 @@ func main() {
 
 	if len(config.faasProcess) == 0 {
 		log.Panicln("Provide a valid process via fprocess environmental variable.")
+		return
+	}
+
+	if *version == true {
+		fmt.Printf("Commit: %v\n", GitCommit)
+		fmt.Printf("Version: %v\n", BuildVersion())
 		return
 	}
 

--- a/watchdog/version.go
+++ b/watchdog/version.go
@@ -1,0 +1,18 @@
+package main
+
+var (
+	//Version release version of the watchdog
+	Version string
+	//GitCommit SHA of the last git commit
+	GitCommit string
+	//DevVerison string for the development version
+	DevVerison = "dev"
+)
+
+//BuildVersion returns current version of watchdog
+func BuildVersion() string {
+	if len(Version) == 0 {
+		return DevVerison
+	}
+	return Version
+}


### PR DESCRIPTION
This changes introduces a new flag -version to watchdog which will
display version and SHA of last git commit.

Version and SHA are injected at build time and passed as a
build-args for Dockerfile.

Fixes: #632

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
