### PR TITLE
Enable deploy_stack scripts to use sudo

### DIFF
--- a/check_user.sh
+++ b/check_user.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Check if a user is root or is in the docker group
+# The exit code is 0 if the user has permissions
+# to run docker commands
+# The exit code 1 if the user has to run docker
+# commands using sudo
+
+retval=1
+if [ $(id -u) == 0 ]; then
+  retval=0
+else
+  for group in $(groups)
+  do
+    if [ $group == 'docker' ]; then
+      retval=0
+      break
+    fi
+  done
+fi
+exit $retval

--- a/deploy_stack.armhf.sh
+++ b/deploy_stack.armhf.sh
@@ -6,4 +6,10 @@ if ! [ -x "$(command -v docker)" ]; then
 fi
 
 echo "Deploying stack"
-docker stack deploy func --compose-file docker-compose.armhf.yml
+command='docker stack deploy func --compose-file docker-compose.armhf.yml'
+
+if ./check_user.sh; then
+  $command
+else
+  sudo $command
+fi

--- a/deploy_stack.sh
+++ b/deploy_stack.sh
@@ -6,5 +6,10 @@ if ! [ -x "$(command -v docker)" ]; then
 fi
 
 echo "Deploying stack"
-docker stack deploy func --compose-file docker-compose.yml
+command='docker stack deploy func --compose-file docker-compose.yml'
 
+if ./check_user.sh; then
+  $command
+else
+  sudo $command
+fi


### PR DESCRIPTION
Some users do not run docker commands as sudo. This enables deploy_stack.sh and deploy_stack.armhf.sh to check if the user is root or if the user is in the 'docker' group. 

## Description
A new script was added to check if a user has privileges to run docker commands. It checks to see if the user is root. If the user is not root it will check to see if the user is in the 'docker' group. If either one of these conditions are met the script exists with 0. Otherwise it exits with 1.
The deploy_stack.sh and the deploy_stack.armhf.sh then use the check_user.sh script to check if the user has privileges or not and then prepends 'sudo' to the command accordingly

## Motivation and Context
I have raised an issue to propose this change: https://github.com/openfaas/faas/issues/664

## How Has This Been Tested?
I have not tested the deploy_stack.armhf.sh. To test the deploy_stack.sh, I added my user to the docker group and ran the script.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
