### PR TITLE
Enable basic auth on gateway

### DIFF
--- a/docker-compose.armhf.yml
+++ b/docker-compose.armhf.yml
@@ -15,6 +15,8 @@ services:
             faas_nats_port: 4222
             direct_functions: "true"    # Functions are invoked directly over the overlay network
             direct_functions_suffix: ""
+            basic_auth: "false"
+            secret_mount_path: "/run/secrets/"
         deploy:
             resources:
                 # limits:   # uncomment to enable limits

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
             faas_nats_port: 4222
             direct_functions: "true"    # Functions are invoked directly over the overlay network
             direct_functions_suffix: ""
+            basic_auth: "false"
+            secret_mount_path: "/run/secrets/"
         deploy:
             resources:
                 # limits:   # Enable if you want to limit memory usage

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -54,3 +54,5 @@ The gateway can be configured through the following environment variables:
 | `faas_promethus_port`         | Port to connect to Prometheus. Default: `9090` |
 | `direct_functions`            | `true` or `false` -  functions are invoked directly over overlay network without passing through provider |
 | `direct_functions_suffix`     | Provide a DNS suffix for invoking functions directly over overlay network  |
+| `basic_auth`              | Set to `true` or `false` to enable embedded basic auth on the /system and /ui endpoints (recommended) |
+| `secret_mount_path`       | Set a location where you have mounted `basic-auth-user` and `basic-auth-password`, default: `/run/secrets/`. |

--- a/gateway/handlers/basic_auth.go
+++ b/gateway/handlers/basic_auth.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"net/http"
+)
+
+// DecorateWithBasicAuth enforces basic auth as a middleware with given credentials
+func DecorateWithBasicAuth(next http.HandlerFunc, credentials *BasicAuthCredentials) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		user, password, ok := r.BasicAuth()
+		w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+
+		if !ok || !(credentials.Password == password && user == credentials.User) {
+
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("invalid credentials"))
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	}
+}
+
+// BasicAuthCredentials for credentials
+type BasicAuthCredentials struct {
+	User     string
+	Password string
+}

--- a/gateway/handlers/basic_auth.go
+++ b/gateway/handlers/basic_auth.go
@@ -2,10 +2,12 @@ package handlers
 
 import (
 	"net/http"
+
+	"github.com/openfaas/faas/gateway/types"
 )
 
 // DecorateWithBasicAuth enforces basic auth as a middleware with given credentials
-func DecorateWithBasicAuth(next http.HandlerFunc, credentials *BasicAuthCredentials) http.HandlerFunc {
+func DecorateWithBasicAuth(next http.HandlerFunc, credentials *types.BasicAuthCredentials) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		user, password, ok := r.BasicAuth()
@@ -20,10 +22,4 @@ func DecorateWithBasicAuth(next http.HandlerFunc, credentials *BasicAuthCredenti
 
 		next.ServeHTTP(w, r)
 	}
-}
-
-// BasicAuthCredentials for credentials
-type BasicAuthCredentials struct {
-	User     string
-	Password string
 }

--- a/gateway/handlers/basic_auth_test.go
+++ b/gateway/handlers/basic_auth_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/openfaas/faas/gateway/types"
 )
 
 func Test_AuthWithValidPassword_Gives200(t *testing.T) {
@@ -18,7 +20,7 @@ func Test_AuthWithValidPassword_Gives200(t *testing.T) {
 	wantPassword := "password"
 	r := httptest.NewRequest(http.MethodGet, "http://localhost:8080", nil)
 	r.SetBasicAuth(wantUser, wantPassword)
-	wantCredentials := &BasicAuthCredentials{
+	wantCredentials := &types.BasicAuthCredentials{
 		User:     wantUser,
 		Password: wantPassword,
 	}
@@ -47,7 +49,7 @@ func Test_AuthWithInvalidPassword_Gives403(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "http://localhost:8080", nil)
 	r.SetBasicAuth(wantUser, wantPassword)
 
-	wantCredentials := &BasicAuthCredentials{
+	wantCredentials := &types.BasicAuthCredentials{
 		User:     wantUser,
 		Password: "",
 	}

--- a/gateway/handlers/basic_auth_test.go
+++ b/gateway/handlers/basic_auth_test.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_AuthWithValidPassword_Gives200(t *testing.T) {
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "<html><body>Hello World!</body></html>")
+	}
+	w := httptest.NewRecorder()
+
+	wantUser := "admin"
+	wantPassword := "password"
+	r := httptest.NewRequest(http.MethodGet, "http://localhost:8080", nil)
+	r.SetBasicAuth(wantUser, wantPassword)
+	wantCredentials := &BasicAuthCredentials{
+		User:     wantUser,
+		Password: wantPassword,
+	}
+
+	decorated := DecorateWithBasicAuth(handler, wantCredentials)
+	decorated.ServeHTTP(w, r)
+
+	wantCode := http.StatusOK
+
+	if w.Code != wantCode {
+		t.Errorf("status code, want: %d, got: %d", wantCode, w.Code)
+		t.Fail()
+	}
+}
+
+func Test_AuthWithInvalidPassword_Gives403(t *testing.T) {
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "<html><body>Hello World!</body></html>")
+	}
+
+	w := httptest.NewRecorder()
+
+	wantUser := "admin"
+	wantPassword := "test"
+	r := httptest.NewRequest(http.MethodGet, "http://localhost:8080", nil)
+	r.SetBasicAuth(wantUser, wantPassword)
+
+	wantCredentials := &BasicAuthCredentials{
+		User:     wantUser,
+		Password: "",
+	}
+
+	decorated := DecorateWithBasicAuth(handler, wantCredentials)
+	decorated.ServeHTTP(w, r)
+
+	wantCode := http.StatusUnauthorized
+	if w.Code != wantCode {
+		t.Errorf("status code, want: %d, got: %d", wantCode, w.Code)
+		t.Fail()
+	}
+}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -5,10 +5,8 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -35,24 +33,17 @@ func main() {
 
 	log.Printf("Binding to external function provider: %s", config.FunctionsProviderURL)
 
-	var credentials *handlers.BasicAuthCredentials
+	var credentials *types.BasicAuthCredentials
 
 	if config.UseBasicAuth {
-		userPath := "/var/secrets/basic_auth_user"
-		user, userErr := ioutil.ReadFile(userPath)
-		if userErr != nil {
-			log.Panicf("Unable to load %s", userPath)
+		var readErr error
+		reader := types.ReadBasicAuthFromDisk{
+			SecretMountPath: config.SecretMountPath,
 		}
+		credentials, readErr = reader.Read()
 
-		userPassword := "/var/secrets/basic_auth_password"
-		password, passErr := ioutil.ReadFile(userPassword)
-		if passErr != nil {
-			log.Panicf("Unable to load %s", userPassword)
-		}
-
-		credentials = &handlers.BasicAuthCredentials{
-			User:     strings.TrimSpace(string(user)),
-			Password: strings.TrimSpace(string(password)),
+		if readErr != nil {
+			log.Panicf(readErr.Error())
 		}
 	}
 

--- a/gateway/types/load_credentials.go
+++ b/gateway/types/load_credentials.go
@@ -1,0 +1,49 @@
+package types
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"strings"
+)
+
+// BasicAuthCredentials for credentials
+type BasicAuthCredentials struct {
+	User     string
+	Password string
+}
+
+type ReadBasicAuth interface {
+	Read() (error, *BasicAuthCredentials)
+}
+
+type ReadBasicAuthFromDisk struct {
+	SecretMountPath string
+}
+
+func (r *ReadBasicAuthFromDisk) Read() (*BasicAuthCredentials, error) {
+	var credentials *BasicAuthCredentials
+
+	if len(r.SecretMountPath) == 0 {
+		return nil, fmt.Errorf("invalid SecretMountPath specified for reading secrets")
+	}
+
+	userPath := path.Join(r.SecretMountPath, "basic-auth-user")
+	user, userErr := ioutil.ReadFile(userPath)
+	if userErr != nil {
+		return nil, fmt.Errorf("unable to load %s", userPath)
+	}
+
+	userPassword := path.Join(r.SecretMountPath, "basic-auth-password")
+	password, passErr := ioutil.ReadFile(userPassword)
+	if passErr != nil {
+		return nil, fmt.Errorf("Unable to load %s", userPassword)
+	}
+
+	credentials = &BasicAuthCredentials{
+		User:     strings.TrimSpace(string(user)),
+		Password: strings.TrimSpace(string(password)),
+	}
+
+	return credentials, nil
+}

--- a/gateway/types/readconfig.go
+++ b/gateway/types/readconfig.go
@@ -107,6 +107,12 @@ func (ReadConfig) Read(hasEnv HasEnv) GatewayConfig {
 
 	cfg.UseBasicAuth = parseBoolValue(hasEnv.Getenv("basic_auth"))
 
+	secretPath := hasEnv.Getenv("secret_mount_path")
+	if len(secretPath) == 0 {
+		secretPath = "/run/secrets/"
+	}
+	cfg.SecretMountPath = secretPath
+
 	return cfg
 }
 
@@ -145,6 +151,9 @@ type GatewayConfig struct {
 
 	// If set, reads secrets from file-system for enabling basic auth.
 	UseBasicAuth bool
+
+	// SecretMountPath specifies where to read secrets from for embedded basic auth
+	SecretMountPath string
 }
 
 // UseNATS Use NATSor not

--- a/gateway/types/readconfig.go
+++ b/gateway/types/readconfig.go
@@ -105,6 +105,8 @@ func (ReadConfig) Read(hasEnv HasEnv) GatewayConfig {
 	cfg.DirectFunctions = parseBoolValue(hasEnv.Getenv("direct_functions"))
 	cfg.DirectFunctionsSuffix = hasEnv.Getenv("direct_functions_suffix")
 
+	cfg.UseBasicAuth = parseBoolValue(hasEnv.Getenv("basic_auth"))
+
 	return cfg
 }
 
@@ -140,6 +142,9 @@ type GatewayConfig struct {
 
 	// If set this will be used to resolve functions directly
 	DirectFunctionsSuffix string
+
+	// If set, reads secrets from file-system for enabling basic auth.
+	UseBasicAuth bool
 }
 
 // UseNATS Use NATSor not

--- a/gateway/types/readconfig_test.go
+++ b/gateway/types/readconfig_test.go
@@ -209,11 +209,18 @@ func TestRead_BasicAuthDefaults(t *testing.T) {
 		t.Logf("config.UseBasicAuth, want: %t, got: %t\n", false, config.UseBasicAuth)
 		t.Fail()
 	}
+
+	wantSecretsMount := "/run/secrets/"
+	if config.SecretMountPath != wantSecretsMount {
+		t.Logf("config.SecretMountPath, want: %s, got: %s\n", wantSecretsMount, config.SecretMountPath)
+		t.Fail()
+	}
 }
 
 func TestRead_BasicAuth_SetTrue(t *testing.T) {
 	defaults := NewEnvBucket()
 	defaults.Setenv("basic_auth", "true")
+	defaults.Setenv("secret_mount_path", "/etc/openfaas/")
 
 	readConfig := ReadConfig{}
 
@@ -221,6 +228,12 @@ func TestRead_BasicAuth_SetTrue(t *testing.T) {
 
 	if config.UseBasicAuth != true {
 		t.Logf("config.UseBasicAuth, want: %t, got: %t\n", true, config.UseBasicAuth)
+		t.Fail()
+	}
+
+	wantSecretsMount := "/etc/openfaas/"
+	if config.SecretMountPath != wantSecretsMount {
+		t.Logf("config.SecretMountPath, want: %s, got: %s\n", wantSecretsMount, config.SecretMountPath)
 		t.Fail()
 	}
 }

--- a/gateway/types/readconfig_test.go
+++ b/gateway/types/readconfig_test.go
@@ -197,3 +197,30 @@ func TestRead_PrometheusDefaults(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestRead_BasicAuthDefaults(t *testing.T) {
+	defaults := NewEnvBucket()
+
+	readConfig := ReadConfig{}
+
+	config := readConfig.Read(defaults)
+
+	if config.UseBasicAuth != false {
+		t.Logf("config.UseBasicAuth, want: %t, got: %t\n", false, config.UseBasicAuth)
+		t.Fail()
+	}
+}
+
+func TestRead_BasicAuth_SetTrue(t *testing.T) {
+	defaults := NewEnvBucket()
+	defaults.Setenv("basic_auth", "true")
+
+	readConfig := ReadConfig{}
+
+	config := readConfig.Read(defaults)
+
+	if config.UseBasicAuth != true {
+		t.Logf("config.UseBasicAuth, want: %t, got: %t\n", true, config.UseBasicAuth)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes https://github.com/openfaas/faas/issues/687 allowing the
gateway to handle the responsibility of basic auth for when it is
in use.

To enable set basic_auth env-var to true and then mount two
secrets or plaintext files under /var/secrets/

basic_auth_user, basic_auth_password

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#687

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with faas-cli list/deploy and with Safari browser.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.