### PR TITLE
Update secret docs and sample-functions

### DIFF
--- a/guide/secure_secret_management.md
+++ b/guide/secure_secret_management.md
@@ -4,7 +4,8 @@ OpenFaaS deploys functions as Docker Swarm Services, as result there are several
 
 ## Using Environment Variables
 
-First, and least secure, is the ability to set environment variables at deploy time. For example, you might want to set the `NODE_ENV` or `DEBUG` variable.  Setting the `NODE_ENV` in the stack file `samples.yml`
+First, and least secure, is the ability to set environment variables at deploy time. For example, you might want to set the `NODE_ENV` or `DEBUG` variable. Setting the `NODE_ENV` in the stack file `samples.yml`
+
 ```yaml
 provider:
   name: faas
@@ -20,6 +21,7 @@ functions:
 ```
 
 You can then deploy and invoke the function via the `faas-cli` using
+
 ```sh
 $ faas-cli deploy -f ./samples.yml
 $ faas-cli invoke nodehelloenv
@@ -28,12 +30,11 @@ Hello from a production machine
 
 Notice that it is using the value of `NODE_ENV` from the stack file, the default is is `dev`.
 
-
 ## Using Swarm Secrets
 
-_Note_: The examples in the following section require `faas-cli` version `>=0.5.1`.
+_Note_: Secrets are mounted as files to `/var/openfaas/secrets`, prior to version `0.8.2` secrets were mounted to `/run/secrets`. The example functions demonstrate a smooth upgrade implementation.
 
-For sensitive value we can leverage the [Docker Swarm Secrets](https://docs.docker.com/engine/swarm/secrets/) feature to safely store and give our functions access to the needed values. Using secrets is a two step process.  Take the [ApiKeyProtected](../sample-functions/ApiKeyProtected) example function, when we deploy this function we provide a secret key that it uses to authenticate requests to it.  First we must add a secret to the swarm
+For sensitive value we can leverage the [Docker Swarm Secrets](https://docs.docker.com/engine/swarm/secrets/) feature to safely store and give our functions access to the needed values. Using secrets is a two step process. Take the [ApiKeyProtected](../sample-functions/ApiKeyProtected) example function, when we deploy this function we provide a secret key that it uses to authenticate requests to it. First we must add a secret to the swarm
 
 ```sh
 docker secret create secret_api_key ~/secrets/secret_api_key.txt
@@ -52,7 +53,6 @@ echo "R^YqzKzSJw51K9zPpQ3R3N" | docker secret create secret_api_key -
 ```
 
 Now, with the secret defined, we can deploy the function like this
-
 
 ```sh
 $ echo "R^YqzKzSJw51K9zPpQ3R3N" | docker secret create secret_api_key -
@@ -75,6 +75,7 @@ Access denied!
 ```
 
 Your `samples.yml` stack file looks like this
+
 ```yaml
 provider:
   name: faas
@@ -87,11 +88,11 @@ functions:
     image: functions/api-key-protected:latest
 ```
 
-Note that unlike the `envVars` in the first example, we do not provide the secret value, just a list of names: `"secrets": ["secret_api_key"]`. The secret value has already been securely stored in the Docker swarm.  One really great result of this type of configuration is that you can simplify your function code by always referencing the same secret name, no matter the environment, the only change is how the environments are configured.
+Note that unlike the `envVars` in the first example, we do not provide the secret value, just a list of names: `"secrets": ["secret_api_key"]`. The secret value has already been securely stored in the Docker swarm. One really great result of this type of configuration is that you can simplify your function code by always referencing the same secret name, no matter the environment, the only change is how the environments are configured.
 
-## Advanced Swarm Secrets
+<!-- ## Advanced Swarm Secrets
 
-For various reasons, you might add a secret to the Swarm under a different name than you want to use in your function, e.g. if you are rotating a secret key. The Docker Swarm secret specification allows us some advanced configuration of secrets [by supplying a comma-separated value specifying the secret](https://docs.docker.com/engine/reference/commandline/service_create/#create-a-service-with-secrets).  The is best show in an example. Let's change the api key on our example function.
+For various reasons, you might add a secret to the Swarm under a different name than you want to use in your function, e.g. if you are rotating a secret key. The Docker Swarm secret specification allows us some advanced configuration of secrets [by supplying a comma-separated value specifying the secret](https://docs.docker.com/engine/reference/commandline/service_create/#create-a-service-with-secrets). The is best show in an example. Let's change the api key on our example function.
 
 First add a new secret key
 
@@ -112,4 +113,4 @@ $ curl -H "Content-Type: application/json" \
 Unlocked the function!
 ```
 
-We reuse the sample stack file as in the previous section.
+We reuse the sample stack file as in the previous section. -->

--- a/sample-functions/ApiKeyProtected-Secrets/handler.go
+++ b/sample-functions/ApiKeyProtected-Secrets/handler.go
@@ -8,10 +8,21 @@ import (
 	"strings"
 )
 
+func getAPISecret(secretName string) (secretBytes []byte, err error) {
+	// read from the openfaas secrets folder
+	secretBytes, err = ioutil.ReadFile("/var/openfaas/secrets/" + secretName)
+	if err != nil {
+		// read from the original location for backwards compatibility with openfaas <= 0.8.2
+		secretBytes, err = ioutil.ReadFile("/run/secrets/" + secretName)
+	}
+
+	return secretBytes, err
+}
+
 func handle(body []byte) {
 	key := os.Getenv("Http_X_Api_Key")
 
-	secretBytes, err := ioutil.ReadFile("/run/secrets/secret_api_key")
+	secretBytes, err := getAPISecret("secret_api_key")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sample-functions/apikey-secret/handler.go
+++ b/sample-functions/apikey-secret/handler.go
@@ -7,12 +7,23 @@ import (
 	"strings"
 )
 
+func getAPISecret(secretName string) (secretBytes []byte, err error) {
+	// read from the openfaas secrets folder
+	secretBytes, err = ioutil.ReadFile("/var/openfaas/secrets/" + secretName)
+	if err != nil {
+		// read from the original location for backwards compatibility with openfaas <= 0.8.2
+		secretBytes, err = ioutil.ReadFile("/run/secrets/" + secretName)
+	}
+
+	return secretBytes, err
+}
+
 // Handle a serverless request
 func Handle(req []byte) string {
 
 	key := os.Getenv("Http_X_Api_Key") // converted via the Header: X-Api-Key
 
-	secretBytes, err := ioutil.ReadFile("/run/secrets/secret_api_key") // You must create a secret ahead of time named `secret_api_key`
+	secretBytes, err := getAPISecret("secret_api_key") // You must create a secret ahead of time named `secret_api_key`
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION

## Description
- Update the documentation about secret management to note the changed
file location
- Remove the documentation on secret rotation, because this will not
currently work
- Update apikey-secret and ApiKeyProtected-Secrets to read secret values
from both the old and the new locations

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Recent updates to faas-swarm and faas-netes changed the mount location
of secrets to implement #692.  These changes update the docs to reflect this change.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
