### PR TITLE
docs: add link to documentation source repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Other [Sample functions](https://github.com/openfaas/faas/tree/master/sample-fun
 
 ## Documentation
 
-We are building a new documentation site at [docs.openfaas.com](http://docs.openfaas.com).
+We are building a new documentation site at [docs.openfaas.com](http://docs.openfaas.com). 
+The source repository for the documentation website is [openfaas/docs](https://github.com/openfaas/docs).
 
 For all other guides, tutorials, trouble-shooting and blog posts head over to our [guides page](https://github.com/openfaas/faas/tree/master/guide) on GitHub.
 


### PR DESCRIPTION
Add a link to the documentation source repo 

Signed-off-by: Edward Wilde <ewilde@gmail.com>