### PR TITLE
Remove PWD link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,14 @@ The deployment guide for Docker Swarm contains a simple one-line command to get 
 
 [Deployment guide for Docker Swarm](http://docs.openfaas.com/deployment/docker-swarm/)
 
-The new login feature breaks the one-click deployment to PWD.
 **Docker Playground**
 
-You can quickly start OpenFaaS on Docker Swarm online using the community-run Docker playground: play-with-docker.com (PWD) by clicking the button below:
+You can quickly start OpenFaaS on Docker Swarm online using the community-run Docker playground: [Play-with-Docker](https://labs.play-with-docker.com/) (PWD)
 
-[![Try in PWD](https://cdn.rawgit.com/play-with-docker/stacks/cff22438/assets/images/button.png)](http://play-with-docker.com?stack=https://raw.githubusercontent.com/openfaas/faas/master/docker-compose.yml&stack_name=func)
+Simply follow the deployment guide for Swarm above in a new session
+
+> You will need a free Docker Hub account to get access. Get one here: [Docker Hub](https://hub.docker.com/)
+
 
 #### Begin the TestDrive
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves #711 

## Description
<!--- Describe your changes in detail -->
This update removes the PWD button from the readme
Play-with-Docker was unreliable for automatic deployment causing
confusion with users attempting to get started quickly

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Walked through the steps to verify they are valid for a PWD deployment. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
