### PR TITLE
[WIP] Trim tailing slash from service name before proxy

### DIFF
--- a/gateway/handlers/forwarding_proxy.go
+++ b/gateway/handlers/forwarding_proxy.go
@@ -133,7 +133,7 @@ func getServiceName(urlValue string) string {
 	if strings.HasPrefix(urlValue, forward) {
 		serviceName = urlValue[len(forward):]
 	}
-	return serviceName
+	return strings.Trim(serviceName, "/")
 }
 
 // LoggingNotifier notifies a log about a request
@@ -168,7 +168,6 @@ type FunctionAsHostBaseURLResolver struct {
 
 // Resolve the base URL for a request
 func (f FunctionAsHostBaseURLResolver) Resolve(r *http.Request) string {
-
 	svcName := getServiceName(r.URL.Path)
 
 	const watchdogPort = 8080

--- a/gateway/handlers/forwarding_proxy_test.go
+++ b/gateway/handlers/forwarding_proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"testing"
 )
 
@@ -65,4 +66,53 @@ func Test_buildUpstreamRequest_NoBody_GetMethod_NoQuery(t *testing.T) {
 		t.Fail()
 	}
 
+}
+
+func Test_getServiceName(t *testing.T) {
+	scenarios := []struct {
+		name        string
+		url         string
+		serviceName string
+	}{
+		{
+			name:        "can handle request without trailing slash",
+			url:         "/function/testFunc",
+			serviceName: "testFunc",
+		},
+		{
+			name:        "can handle request with trailing slash",
+			url:         "/function/testFunc/",
+			serviceName: "testFunc",
+		},
+		{
+			name:        "can handle request with query parameters",
+			url:         "/function/testFunc?name=foo",
+			serviceName: "testFunc",
+		},
+		{
+			name:        "can handle request with trailing slash and query parameters",
+			url:         "/function/testFunc/?name=foo",
+			serviceName: "testFunc",
+		},
+		{
+			name:        "can handle request with a fragment",
+			url:         "/function/testFunc#fragment",
+			serviceName: "testFunc",
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+
+			u, err := url.Parse("http://openfaas.local" + s.url)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			service := getServiceName(u.Path)
+			if service != s.serviceName {
+				t.Fatalf("Incorrect service name - want: %s, got: %s", s.serviceName, service)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When determining the service name of the function, remove any trailing
slashes, the slashes are not allowed in service names for either Swarm
or K8S, so this can only be a left over from the url path

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

- This was preventing service resolution, and hence failed functions,
    when the function was called with a trailing slash. See #714

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have added a unit test, I have not tested a deploy yet because it is getting late here, but I wanted to get something posted incase someone else was feeling like testing.

I did run my test prior to update the method, and they were failing with the trailing slash.  They now pass. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
