### PR TITLE
Update to golang 1.9.7

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -26,7 +26,7 @@ You can find the [reference documentation for the Watchdog here](https://github.
 This is the basis of a function which generates HTML from MarkDown:
 
 ```
-FROM golang:1.9.4
+FROM golang:1.9.7
 RUN mkdir -p /go/src/app
 COPY handler.go /go/src/app
 WORKDIR /go/src/app

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.4 as build
+FROM golang:1.9.7 as build
 
 RUN curl -sL https://github.com/alexellis/license-check/releases/download/0.2.2/license-check \
       > /usr/bin/license-check \

--- a/gateway/Dockerfile.arm64
+++ b/gateway/Dockerfile.arm64
@@ -1,5 +1,4 @@
-#FROM alexellis2/golang:1.9-arm64 as build
-FROM golang:1.9.2 as build
+FROM golang:1.9.7 as build
 WORKDIR /go/src/github.com/openfaas/faas/gateway
 
 #RUN curl -sL https://github.com/alexellis/license-check/releases/download/0.1/license-check > /usr/bin/license-check && chmod +x /usr/bin/license-check

--- a/gateway/Dockerfile.armhf
+++ b/gateway/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM golang:1.9.6 as build
+FROM golang:1.9.7 as build
 
 WORKDIR /go/src/github.com/openfaas/faas/gateway
 

--- a/sample-functions/ApiKeyProtected-Secrets/Dockerfile
+++ b/sample-functions/ApiKeyProtected-Secrets/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.4-alpine as builder
+FROM golang:1.9.7-alpine as builder
 
 MAINTAINER alex@openfaas.com
 ENTRYPOINT []

--- a/sample-functions/BaseFunctions/golang/Dockerfile
+++ b/sample-functions/BaseFunctions/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.4-alpine
+FROM golang:1.9.7-alpine
 
 MAINTAINER alexellis2@gmail.com
 ENTRYPOINT []

--- a/sample-functions/BaseFunctions/golang/Dockerfile.win
+++ b/sample-functions/BaseFunctions/golang/Dockerfile.win
@@ -1,4 +1,4 @@
-FROM golang:1.9.4-windowsservercore
+FROM golang:1.9.7-windowsservercore
 MAINTAINER alexellis2@gmail.com
 ENTRYPOINT []
 

--- a/sample-functions/DockerHubStats/Dockerfile
+++ b/sample-functions/DockerHubStats/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.4-alpine as builder
+FROM golang:1.9.7-alpine as builder
 
 MAINTAINER alex@openfaas.com
 ENTRYPOINT []

--- a/sample-functions/DockerHubStats/Dockerfile.armhf
+++ b/sample-functions/DockerHubStats/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM golang:1.9.4-alpine as builder
+FROM golang:1.9.7-alpine as builder
 
 MAINTAINER alex@openfaas.com
 ENTRYPOINT []

--- a/sample-functions/MarkdownRender/Dockerfile
+++ b/sample-functions/MarkdownRender/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.4-alpine as builder
+FROM golang:1.9.7-alpine as builder
 
 MAINTAINER alex@openfaas.com
 ENTRYPOINT []

--- a/sample-functions/WebhookStash/Dockerfile
+++ b/sample-functions/WebhookStash/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.4-alpine as builder
+FROM golang:1.9.7-alpine as builder
 
 MAINTAINER alex@openfaas.com
 ENTRYPOINT []

--- a/watchdog/Dockerfile
+++ b/watchdog/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.4 as build
+FROM golang:1.9.7 as build
 ARG VERSION
 ARG GIT_COMMIT
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates all the references to golang from 1.9.4 (and 1.9.2 in the case of the gateway arm64 image) to 1.9.7.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Issue #660 has been open for a while and seemed like it would make a good first issue.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Basic tests using functions loaded from the function store including the nslookup, hubstats, and nodeinfo using my dev docker images in swarm on an x86_64 VM.  I also deployed the updated gateway to my raspberry pi kubernetes cluster and validated that the nodeinfo and nslookup worked.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
