### PR TITLE
[WIP] Adding support for optional read-only fs for functions

### DIFF
--- a/gateway/requests/requests.go
+++ b/gateway/requests/requests.go
@@ -41,6 +41,9 @@ type CreateFunctionRequest struct {
 
 	// Requests of resources requested by function
 	Requests *FunctionResources `json:"requests"`
+
+	// Flag for enabling a readonly filesystem for the function.
+	ReadOnlyFs bool `json:"readOnlyFs"`
 }
 
 // FunctionResources Memory and CPU


### PR DESCRIPTION
This pull request lays the foundation for adding read-only fs functions. The flag needs to be set to true in order to enable it. By default, it will be disabled and behave like currently. 

## Motivation and Context
- [x] I have raised an issue to propose this change (#590)


## How Has This Been Tested?
The tests will be in the OpenFaaS provider.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
