### PR TITLE
Update nats-queue-worker package to 0.4.7

### DIFF
--- a/gateway/Gopkg.lock
+++ b/gateway/Gopkg.lock
@@ -75,8 +75,8 @@
 [[projects]]
   name = "github.com/openfaas/nats-queue-worker"
   packages = ["handler"]
-  revision = "62e8dcfe87fc01de8b94156f3e4291370c0c84a8"
-  version = "0.4.6"
+  revision = "15287c9b2af293cee0c545ccc014a68e1f0a4424"
+  version = "0.4.7"
 
 [[projects]]
   name = "github.com/prometheus/client_golang"
@@ -112,6 +112,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "181fb3c695e3b12e0a8e967135ef717ea83d9525c7c31b92f641d7a963d26254"
+  inputs-digest = "f6e74bc55788e9ad6ea33f02d2be398013705f4606c29bbead71ac41a3c19514"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/gateway/Gopkg.toml
+++ b/gateway/Gopkg.toml
@@ -14,7 +14,7 @@ ignored = ["github.com/openfaas/faas/gateway/queue"]
 
 [[constraint]]
   name = "github.com/openfaas/nats-queue-worker"
-  version = "0.4.5"
+  version = "0.4.7"
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"

--- a/gateway/vendor/github.com/openfaas/nats-queue-worker/.travis.yml
+++ b/gateway/vendor/github.com/openfaas/nats-queue-worker/.travis.yml
@@ -17,7 +17,7 @@ install:
   - echo "Please don't go get"
 
 script:
-  - cd queue-worker && ./build.sh
+  - ./build.sh
 
 after_success:
     - if [ ! -z "$TRAVIS_TAG" ] ; then

--- a/gateway/vendor/github.com/openfaas/nats-queue-worker/Gopkg.toml
+++ b/gateway/vendor/github.com/openfaas/nats-queue-worker/Gopkg.toml
@@ -33,6 +33,10 @@
   name = "github.com/openfaas/faas"
   version = "0.8.2"
 
+[[constraint]]
+  name = "github.com/nats-io/go-nats"
+  version = "v1.5.0"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/gateway/vendor/github.com/openfaas/nats-queue-worker/handler/handler.go
+++ b/gateway/vendor/github.com/openfaas/nats-queue-worker/handler/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nats-io/go-nats-streaming"
 	"github.com/openfaas/faas/gateway/queue"
+	"regexp"
 )
 
 // NatsQueue queue for work
@@ -22,9 +23,11 @@ type NatsConfig interface {
 type DefaultNatsConfig struct {
 }
 
+var supportedCharacters, _ = regexp.Compile("[^a-zA-Z0-9-_]+")
+
 func (DefaultNatsConfig) GetClientID() string {
 	val, _ := os.Hostname()
-	return "faas-publisher-" + val
+	return getClientId(val)
 }
 
 // CreateNatsQueue ready for asynchronous processing
@@ -57,4 +60,8 @@ func (q *NatsQueue) Queue(req *queue.Request) error {
 	err = q.nc.Publish("faas-request", out)
 
 	return err
+}
+
+func getClientId(hostname string) string {
+	return "faas-publisher-" + supportedCharacters.ReplaceAllString(hostname, "_")
 }

--- a/gateway/vendor/github.com/openfaas/nats-queue-worker/handler/handler_test.go
+++ b/gateway/vendor/github.com/openfaas/nats-queue-worker/handler/handler_test.go
@@ -17,3 +17,23 @@ func Test_GetClientID_ContainsHostname(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestCreateClientId(t *testing.T) {
+	clientId := getClientId("computer-a")
+	expected := "faas-publisher-computer-a"
+	if clientId != expected {
+		t.Logf("Expected client id `%s` actual `%s`\n", expected, clientId)
+		t.Fail()
+	}
+}
+
+func TestCreateClientIdWhenHostHasUnsupportedCharacters(t *testing.T) {
+	clientId := getClientId("computer-a.acme.com")
+	expected := "faas-publisher-computer-a_acme_com"
+	if clientId != expected {
+		t.Logf("Expected client id `%s` actual `%s`\n", expected, clientId)
+		t.Fail()
+	}
+}
+
+


### PR DESCRIPTION
## Description
Update nats queue worker package to support host names with periods `.`

## Motivation and Context
Without this update you can not run OpenFaas gateway on AWS Fargate

## How Has This Been Tested?
I tested this using the integration pack `gateway/tests/integration`

```
=== RUN   TestCreate_ValidRequest
--- PASS: TestCreate_ValidRequest (0.03s)
=== RUN   TestCreate_InvalidImage
--- PASS: TestCreate_InvalidImage (0.00s)
=== RUN   TestCreate_InvalidNetwork
--- PASS: TestCreate_InvalidNetwork (0.00s)
=== RUN   TestCreate_InvalidJson
--- PASS: TestCreate_InvalidJson (0.00s)
=== RUN   TestDelete_EmptyFunctionGivenFails
--- PASS: TestDelete_EmptyFunctionGivenFails (0.00s)
=== RUN   TestDelete_NonExistingFunctionGives404
--- PASS: TestDelete_NonExistingFunctionGives404 (0.00s)
=== RUN   TestGet_Rejected
2018/06/21 20:59:44 Head http://localhost:8080/function/func_echoit: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
