### PR TITLE
Updated default secret mount path value

### DIFF
--- a/docker-compose.armhf.yml
+++ b/docker-compose.armhf.yml
@@ -16,7 +16,7 @@ services:
             direct_functions: "true"    # Functions are invoked directly over the overlay network
             direct_functions_suffix: ""
             basic_auth: "false"
-            secret_mount_path: "/run/secrets/"
+            secret_mount_path: "/var/openfaas/secrets/"
         deploy:
             resources:
                 # limits:   # uncomment to enable limits

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
             direct_functions: "true"    # Functions are invoked directly over the overlay network
             direct_functions_suffix: ""
             basic_auth: "false"
-            secret_mount_path: "/run/secrets/"
+            secret_mount_path: "/var/openfaas/secrets/"
         deploy:
             resources:
                 # limits:   # Enable if you want to limit memory usage

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -55,4 +55,4 @@ The gateway can be configured through the following environment variables:
 | `direct_functions`            | `true` or `false` -  functions are invoked directly over overlay network without passing through provider |
 | `direct_functions_suffix`     | Provide a DNS suffix for invoking functions directly over overlay network  |
 | `basic_auth`              | Set to `true` or `false` to enable embedded basic auth on the /system and /ui endpoints (recommended) |
-| `secret_mount_path`       | Set a location where you have mounted `basic-auth-user` and `basic-auth-password`, default: `/run/secrets/`. |
+| `secret_mount_path`       | Set a location where you have mounted `basic-auth-user` and `basic-auth-password`, default: `/var/openfaas/secrets/`. |

--- a/gateway/types/readconfig.go
+++ b/gateway/types/readconfig.go
@@ -109,7 +109,7 @@ func (ReadConfig) Read(hasEnv HasEnv) GatewayConfig {
 
 	secretPath := hasEnv.Getenv("secret_mount_path")
 	if len(secretPath) == 0 {
-		secretPath = "/run/secrets/"
+		secretPath = "/var/openfaas/secrets/"
 	}
 	cfg.SecretMountPath = secretPath
 

--- a/gateway/types/readconfig_test.go
+++ b/gateway/types/readconfig_test.go
@@ -210,7 +210,7 @@ func TestRead_BasicAuthDefaults(t *testing.T) {
 		t.Fail()
 	}
 
-	wantSecretsMount := "/run/secrets/"
+	wantSecretsMount := "/var/openfaas/secrets/"
 	if config.SecretMountPath != wantSecretsMount {
 		t.Logf("config.SecretMountPath, want: %s, got: %s\n", wantSecretsMount, config.SecretMountPath)
 		t.Fail()


### PR DESCRIPTION
This changes updates the secret mount path default value to
/var/openfaas/secrets at serveral places. It has been changed
from /run/secrets/ to /var/openfaas/secrets after version 0.8.2

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested this on my local system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
