### PR TITLE
Enable basic-auth by default

### DIFF
--- a/deploy_stack.sh
+++ b/deploy_stack.sh
@@ -5,6 +5,50 @@ if ! [ -x "$(command -v docker)" ]; then
   exit 1
 fi
 
-echo "Deploying stack"
-docker stack deploy func --compose-file docker-compose.yml
+export BASIC_AUTH="true"
 
+sha_cmd="shasum -a 256"
+if ! command -v shasum >/dev/null; then
+  sha_cmd="sha256sum"
+fi
+
+while [ ! $# -eq 0 ]
+do
+	case "$1" in
+		--no-auth | -n)
+			export BASIC_AUTH="false"
+			;;
+    --help | -h)
+			echo "Usage: \n [default]\tdeploy the OpenFaaS core services\n --no-auth [-n]\tdisable basic authentication.\n --help\tdisplays this screen"
+      exit
+			;;
+	esac
+	shift
+done
+
+# Secrets should be created even if basic-auth is disabled.
+echo "Attempting to create credentials for gateway.."
+echo "admin" | docker secret create basic-auth-user -
+secret=$(head -c 16 /dev/urandom| $sha_cmd | cut -d " " -f 1)
+echo "$secret" | docker secret create basic-auth-password -
+if [ $? = 0 ];
+then
+  echo "[Credentials]\n username: admin \n password: $secret\n echo -n "$secret" | faas-cli login --username=admin --password-stdin"
+else
+  echo "[Credentials]\n already exist, not creating"
+fi
+
+if [ $BASIC_AUTH = "true" ];
+then
+  echo ""
+  echo "Enabling basic authentication for gateway.."
+  echo ""
+else
+  echo ""
+  echo "Disabling basic authentication for gateway.."
+  echo ""
+fi
+
+echo "Deploying OpenFaaS core services"
+
+docker stack deploy func --compose-file docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
             faas_nats_port: 4222
             direct_functions: "true"    # Functions are invoked directly over the overlay network
             direct_functions_suffix: ""
-            basic_auth: "false"
+            basic_auth: "${BASIC_AUTH:-true}"
             secret_mount_path: "/run/secrets/"
         deploy:
             resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.8.3
+        image: openfaas/gateway:0.8.5
         networks:
             - functions
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,9 @@ services:
             placement:
                 constraints:
                     - 'node.platform.os == linux'
-        # secrets:
-        #     - basic-auth-user
-        #     - basic-auth-password
+        secrets:
+            - basic-auth-user
+            - basic-auth-password
 
     # Docker Swarm provider
     faas-swarm:
@@ -180,8 +180,8 @@ networks:
         labels:
           - "openfaas=true"
 
-# secrets:
-#     basic-auth-user:
-#         external: true
-#     basic-auth-password:
-#         external: true
+secrets:
+    basic-auth-user:
+        external: true
+    basic-auth-password:
+        external: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Enable basic-auth by default.

This changes ./deploy_stack.sh to generate and then apply secrets turning
on the built-in basic auth feature of the gateway.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#350 #74 

The deployment script will enable basic-auth by default to help
avoid people deploying to a public IP with no protection from
malicious actors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on MacOS with and without --no-auth flag.
Does not apply for armhf or powershell.

Example workflow for testing:

![screen shot 2018-07-03 at 10 25 22 am](https://user-images.githubusercontent.com/6358735/42212622-8a5f18d2-7eae-11e8-9242-eb3da233a79f.png)

Test with positive and negative workflows: positive - password supplied and consumed, show that auth is working by using wrong password. Negative flow - disable auth and check auth is not required.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Will need documentation change and change to integration tests to disable auth via `--no-auth` flag when deploying during testing.