### PR TITLE
Move watchdog from functions/ to openfaas/ ns

### DIFF
--- a/watchdog/build.sh
+++ b/watchdog/build.sh
@@ -15,12 +15,12 @@ cd watchdog
 if [ ! $http_proxy == "" ] 
 then
     docker build --no-cache --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy \
-        --build-arg GIT_COMMIT=$GIT_COMMIT --build-arg VERSION=$VERSION -t functions/watchdog:build .
+        --build-arg GIT_COMMIT=$GIT_COMMIT --build-arg VERSION=$VERSION -t openfaas/watchdog:build .
 else
-    docker build --no-cache --build-arg VERSION=$VERSION --build-arg GIT_COMMIT=$GIT_COMMIT -t functions/watchdog:build .
+    docker build --no-cache --build-arg VERSION=$VERSION --build-arg GIT_COMMIT=$GIT_COMMIT -t openfaas/watchdog:build .
 fi
 
-docker create --name buildoutput functions/watchdog:build echo
+docker create --name buildoutput openfaas/watchdog:build echo
 
 docker cp buildoutput:/go/src/github.com/openfaas/faas/watchdog/watchdog ./fwatchdog
 docker cp buildoutput:/go/src/github.com/openfaas/faas/watchdog/watchdog-armhf ./fwatchdog-armhf


### PR DESCRIPTION
This moves watchdog to a better name for images and also gives free
image-scanning and gives more confidence  to users  that components
ship regularly and makes any vulnerabilities  in  components  clear

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

[#741](https://github.com/openfaas/faas/issues/741)

## How Has This Been Tested?

Tested with local build

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.