### PR TITLE
Push gateway image to both Quay.io and Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,19 @@ script:
     - sh contrib/ci.sh
 
 after_success:
+    - if [ -z $DOCKER_NS ] ; then
+        export DOCKER_NS=openfaas;
+        fi
+
     - if [ ! -z "$TRAVIS_TAG" ] ; then 
         docker tag $DOCKER_NS/gateway:latest-dev $DOCKER_NS/gateway:$TRAVIS_TAG;
         echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
         docker push $DOCKER_NS/gateway:$TRAVIS_TAG;
+
+        docker tag $DOCKER_NS/gateway:latest-dev quay.io/$DOCKER_NS/gateway:$TRAVIS_TAG;
+        echo $QUAY_PASSWORD | docker login -u=$QUAY_USERNAME --password-stdin quay.io;
+        docker push quay.io/$DOCKER_NS/gateway:$TRAVIS_TAG;
+
         fi
 
 deploy:


### PR DESCRIPTION
With this change gateway will be pushed to Quay.io on release
as a backup

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

[#741](https://github.com/openfaas/faas/issues/741)

## How Has This Been Tested?

Not tested yet. Requires setting environmental variables to Travis.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.