### PR TITLE
Add core contributors / copyright header update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ General format:
 
 **Governance**
 
-OpenFaaS is an independent project created by Alex Ellis in 2016. OpenFaaS is lead by Alex and is being built in the open by a growing community of contributors.
+OpenFaaS is an independent project created by Alex Ellis in 2016. OpenFaaS is led by Alex and is being built in the open by a growing community of contributors.
 
 ## Branding guidelines
 
@@ -180,7 +180,7 @@ Please add a Copyright notice to new files you add where this is not already pre
 
 ### Sign your work
 
-> Note: every commits in your PR or Patch must be signed-off.
+> Note: every commit in your PR or Patch must be signed-off.
 
 The sign-off is a simple line at the end of the explanation for a patch. Your
 signature certifies that you wrote the patch or otherwise have the right to pass

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -23,7 +23,7 @@ COPY version        version
 COPY server.go      .
 
 # Run a gofmt and exclude all vendored code.
-RUN license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Project" "OpenFaaS Authors" \
+RUN license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Project" "OpenFaaS Authors" "OpenFaaS Author(s)" \
     && test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))" \
     && go test $(go list ./... | grep -v integration | grep -v /vendor/ | grep -v /template/) -cover \
     && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Core contributors are added by name.
- Copyright notice now encourages OpenFaaS Author(s) in place of
OpenFaaS Project to reflect the nature of distributed copyright.
