### PR TITLE
Use env-var for basic_auth value for auto-auth script

### DIFF
--- a/deploy_stack.sh
+++ b/deploy_stack.sh
@@ -5,7 +5,8 @@ if ! [ -x "$(command -v docker)" ]; then
   exit 1
 fi
 
-auth="1"
+export BASIC_AUTH="true"
+
 sha_cmd="shasum -a 256"
 if ! command -v shasum >/dev/null; then
   sha_cmd="sha256sum"
@@ -15,7 +16,7 @@ while [ ! $# -eq 0 ]
 do
 	case "$1" in
 		--no-auth | -n)
-			auth=0
+			export BASIC_AUTH="false"
 			;;
     --help | -h)
 			echo "Usage: \n [default]\tdeploy the OpenFaaS core services\n --no-auth [-n]\tdisable basic authentication.\n --help\tdisplays this screen"
@@ -37,7 +38,7 @@ else
   echo "[Credentials]\n already exist, not creating"
 fi
 
-if [ $auth -eq "1" ];
+if [ $BASIC_AUTH = "true" ];
 then
   echo ""
   echo "Enabling basic authentication for gateway.."
@@ -46,7 +47,6 @@ else
   echo ""
   echo "Disabling basic authentication for gateway.."
   echo ""
-  sed -i -r.bak 's/basic_auth: \"true\"/basic_auth: \"false\"/' docker-compose.yml
 fi
 
 echo "Deploying OpenFaaS core services"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
             faas_nats_port: 4222
             direct_functions: "true"    # Functions are invoked directly over the overlay network
             direct_functions_suffix: ""
-            basic_auth: "true"
+            basic_auth: "${BASIC_AUTH:-true}"
             secret_mount_path: "/run/secrets/"
         deploy:
             resources:


### PR DESCRIPTION
This changes uses environment variable to enable and disable basic_auth
configuration in `docker-compose.yml'. It also has default value 'true`
for basic_auth.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested on my local (Docker for mac)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
