### PR TITLE
Adds annotation attribute to CreateFunctionRequest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ fwatchdog-armhf
 **/*.DS_Store
 .vscode
 .idea
+certifier
+.editorconfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,8 @@ addons:
 before_install:
 
 script:
-    - sh build.sh
-    # Invoke ci script too
-    - sh contrib/ci.sh
+    - ./build.sh
+    - ./contrib/ci.sh
 
 after_success:
     - if [ -z $DOCKER_NS ] ; then

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-.PHONY: build
+.PHONY: build build-gateway test-ci
 
 build:
 	./build.sh
 build-gateway:
 	(cd gateway; ./build.sh latest-dev)
+test-ci:
+	./contrib/ci.sh

--- a/api-docs/swagger.yml
+++ b/api-docs/swagger.yml
@@ -263,6 +263,16 @@ definitions:
         additionalProperties:
           type: string
         description: Overrides to environmental variables
+      labels:
+        type: array
+        items:
+          type: string
+        description: An array of labels used by the back-end for making scheduling or routing decisions
+      annotations:
+        type: array
+        items:
+          type: string
+        description: An array of annotations used by the back-end for management, orchestration, events and build tasks
       secrets:
         type: array
         items:

--- a/contrib/ci.sh
+++ b/contrib/ci.sh
@@ -1,39 +1,78 @@
 #!/bin/bash
-
 docker swarm init --advertise-addr=127.0.0.1
+set -e
 
 ./deploy_stack.sh --no-auth
 
 docker service update func_gateway --image=openfaas/gateway:latest-dev
 
 # Script makes sure OpenFaaS API gateway is ready before running tests
-
+wait_success=false
 for i in {1..30};
 do
-  echo "Checking if 127.0.0.1:8000 is up.. ${i}/30" 
-  curl -fs 127.0.0.1:8080/
+  echo "Checking if 127.0.0.1:8000 is up.. ${i}/30"
+  status_code=$(curl --silent --output /dev/stderr --write-out "%{http_code}" http://127.0.0.1:8080/)
 
-  if [ $? -eq 0 ]; then
+  if [ "$status_code" -ge 200 -a "$status_code" -lt 400 ]; then
+     echo "Deploying gateway success"
+     wait_success=true
     break
   fi
   sleep 0.5
 done
 
+if [ "$wait_success" != true ] ; then
+    echo "Failed to wait for gateway"
+    exit 1
+fi
+
 cd ..
 
 echo $GOPATH
 
-mkdir -p $GOPATH/src/github.com/openfaas/
-cp -r faas $GOPATH/src/github.com/openfaas/
+if [ ! -d "$GOPATH/src/github.com/openfaas/" ]; then
+    mkdir -p $GOPATH/src/github.com/openfaas/
+    cp -r faas $GOPATH/src/github.com/openfaas/
+fi
 
-git clone https://github.com/openfaas/certifier
+if [ ! -d "$GOPATH/src/github.com/openfaas/certifier" ]; then
+    git clone https://github.com/openfaas/certifier
+fi
 
-cp -r certifier $GOPATH/src/github.com/openfaas/
+echo "Deploying OpenFaaS stack.yml from $(pwd)/faas"
+command -v faas-cli >/dev/null 2>&1 || curl -sSL https://cli.openfaas.com | sudo sh
+faas-cli deploy -f ./faas/stack.yml
 
+wait_success=false
+for i in {1..30}
+do
+  echo "Checking if 127.0.0.1:8080/function/echoit is up.. ${i}/30"
+  status_code=$(curl --silent --output /dev/stderr --write-out "%{http_code}" http://127.0.0.1:8080/function/echoit -d "hello")
+
+  if [ "$status_code" -ge 200 -a "$status_code" -lt 400 ]; then
+    echo "Deploying OpenFaaS stack.yml success"
+    wait_success=true
+    break
+  else
+    echo "Attempt $i lets try again"
+  fi
+
+  printf '.'
+  sleep 0.5
+done
+
+if [ "$wait_success" != true ] ; then
+    echo "Failed to wait for stack.yml to deploy"
+    exit 1
+fi
+
+echo Running integration tests
 cd $GOPATH/src/github.com/openfaas/faas/gateway/tests/integration && \
-   go test -v
+   go test -v -count=1
 
+echo Running certifier
 cd $GOPATH/src/github.com/openfaas/certifier && \
    make test
 
+echo Integration tests all PASSED
 exit 0

--- a/gateway/requests/requests.go
+++ b/gateway/requests/requests.go
@@ -36,6 +36,10 @@ type CreateFunctionRequest struct {
 	// back-end for making scheduling or routing decisions
 	Labels *map[string]string `json:"labels"`
 
+	// Annotations are metadata for functions which may be used by the
+	// back-end for management, orchestration, events and build tasks
+	Annotations *map[string]string `json:"annotations"`
+
 	// Limits for function
 	Limits *FunctionResources `json:"limits"`
 
@@ -67,6 +71,10 @@ type Function struct {
 	// Labels are metadata for functions which may be used by the
 	// back-end for making scheduling or routing decisions
 	Labels *map[string]string `json:"labels"`
+
+	// Annotations are metadata for functions which may be used by the
+	// back-end for management, orchestration, events and build tasks
+	Annotations *map[string]string `json:"annotations"`
 }
 
 // AsyncReport is the report from a function executed on a queue worker.

--- a/gateway/tests/integration/README.md
+++ b/gateway/tests/integration/README.md
@@ -2,3 +2,15 @@
 
 These tests should be run against the sample stack included in the repository root.
 
+## Deploy the stack
+```
+./deploy_stack.sh
+faas-cli deploy -f ./stack.yml
+```
+
+## Remove the stack
+1. Delete all OpenFaaS deployed functions
+```
+faas-cli remove
+docker stack rm func
+```

--- a/gateway/tests/integration/infohandler_test.go
+++ b/gateway/tests/integration/infohandler_test.go
@@ -34,7 +34,7 @@ func Test_InfoEndpoint_Returns_Gateway_Version_SHA_And_Message(t *testing.T) {
 	gatewayInfo := &types.GatewayInfo{}
 	err = json.Unmarshal([]byte(body), gatewayInfo)
 	if err != nil {
-		t.Log(err)
+		t.Errorf("Could not unmarshal gateway info, response body:%s, error:%s", body, err.Error())
 		t.Fail()
 	}
 

--- a/sample-functions/WebhookStash/handler.go
+++ b/sample-functions/WebhookStash/handler.go
@@ -3,17 +3,17 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"strconv"
 	"time"
-	"log"
 )
 
 func main() {
 	input, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
 		log.Fatalf("Cannot read input %s.\n", err)
-        return
+		return
 	}
 	now := time.Now()
 	stamp := strconv.FormatInt(now.UnixNano(), 10)
@@ -21,7 +21,7 @@ func main() {
 	writeErr := ioutil.WriteFile(stamp+".txt", input, 0644)
 	if writeErr != nil {
 		log.Fatalf("Cannot write input %s.\n", err)
-        return
+		return
 	}
 
 	fmt.Printf("Stashing request: %s.txt\n", stamp)


### PR DESCRIPTION
## Description
Annotation attributes are metadata for functions which may be used by
the back-end for making scheduling or routing decisions.

## Motivation and Context
- [x] Relates to #682

## How Has This Been Tested?
I ran the `contrib/ci.sh` script:
```

Running integration tests
=== RUN   TestCreate_ValidRequest
--- PASS: TestCreate_ValidRequest (0.02s)
=== RUN   TestCreate_InvalidImage
--- PASS: TestCreate_InvalidImage (0.00s)
=== RUN   TestCreate_InvalidNetwork
--- PASS: TestCreate_InvalidNetwork (0.00s)
=== RUN   TestCreate_InvalidJson
--- PASS: TestCreate_InvalidJson (0.00s)
=== RUN   TestDelete_EmptyFunctionGivenFails
--- PASS: TestDelete_EmptyFunctionGivenFails (0.00s)
=== RUN   TestDelete_NonExistingFunctionGives404
--- PASS: TestDelete_NonExistingFunctionGives404 (0.00s)
=== RUN   Test_InfoEndpoint_Returns_200
--- PASS: Test_InfoEndpoint_Returns_200 (0.00s)
=== RUN   Test_InfoEndpoint_Returns_Gateway_Version_SHA_And_Message
--- PASS: Test_InfoEndpoint_Returns_Gateway_Version_SHA_And_Message (0.00s)
=== RUN   TestGet_Rejected
--- PASS: TestGet_Rejected (0.00s)
=== RUN   TestEchoIt_Post_Route_Handler_ForwardsClientHeaders
--- PASS: TestEchoIt_Post_Route_Handler_ForwardsClientHeaders (0.00s)
=== RUN   TestEchoIt_Post_Route_Handler
--- PASS: TestEchoIt_Post_Route_Handler (0.00s)
PASS
ok      github.com/openfaas/faas/gateway/tests/integration      0.044s
Running certifier
make[1]: Entering directory '/home/ewilde/data/go/src/github.com/openfaas/certifier'
gateway_url=http://localhost:8080/ time go test ./tests -v
=== RUN   Test_Deploy_Stronghash
--- PASS: Test_Deploy_Stronghash (0.02s)
=== RUN   Test_InvokeNotFound
--- PASS: Test_InvokeNotFound (10.06s)
        deploy_test.go:127: [1/30] Correct response: 502
=== RUN   Test_Deploy_PassingCustomEnvVars_AndQueryString
=== RUN   Test_Deploy_PassingCustomEnvVars_AndQueryString/Empty_QueryString
=== RUN   Test_Deploy_PassingCustomEnvVars_AndQueryString/Populated_QueryString
--- PASS: Test_Deploy_PassingCustomEnvVars_AndQueryString (12.07s)
    --- PASS: Test_Deploy_PassingCustomEnvVars_AndQueryString/Empty_QueryString (12.06s)
        deploy_test.go:118: [1/30] Bad response want: [200], got: 502
        deploy_test.go:119: http://localhost:8080/function/env-test
        deploy_test.go:127: [2/30] Correct response: 200
    --- PASS: Test_Deploy_PassingCustomEnvVars_AndQueryString/Populated_QueryString (0.00s)
        deploy_test.go:127: [1/30] Correct response: 200
PASS
ok      github.com/openfaas/certifier/tests     (cached)
0.37user 0.08system 0:00.21elapsed 210%CPU (0avgtext+0avgdata 18400maxresident)k
0inputs+16outputs (0major+15636minor)pagefaults 0swaps
make[1]: Leaving directory '/home/ewilde/data/go/src/github.com/openfaas/certifier'
Integration tests all PASSED
```
## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
