### PR TITLE
 Implement proposal 716, passing full URL paths

### DIFF
--- a/gateway/handlers/forwarding_proxy.go
+++ b/gateway/handlers/forwarding_proxy.go
@@ -210,13 +210,26 @@ func (f TransparentURLPathTransformer) Transform(r *http.Request) string {
 	return r.URL.Path
 }
 
-// PathTruncatingURLPathTransformer always truncated the path to "/".
-type PathTruncatingURLPathTransformer struct {
+// FunctionPathTruncatingURLPathTransformer always truncated the path to "/".
+type FunctionPathTruncatingURLPathTransformer struct {
 }
 
 // Transform always return a path of "/".
-func (f PathTruncatingURLPathTransformer) Transform(r *http.Request) string {
-	return "/"
+func (f FunctionPathTruncatingURLPathTransformer) Transform(r *http.Request) string {
+	ret := r.URL.Path
+
+	if ret != "" {
+		matcher := functionMatcher.Copy()
+		parts := matcher.FindStringSubmatch(ret)
+		// In the following regex, in the case of a match the r.URL.Path will be at `0`,
+		// the function name at `1` and the rest of the path (the part we are interested in)
+		// at `2`.  For this transformer, all we need to do is confirm it is a function.
+		if 3 == len(parts) {
+			ret = "/"
+		}
+	}
+
+	return ret
 }
 
 // FunctionPrefixTrimmingURLPathTransformer removes the "/function/servicename/" prefix from the URL path.

--- a/gateway/handlers/forwarding_proxy.go
+++ b/gateway/handlers/forwarding_proxy.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Parse out the service name (group 1) and rest of path (group 2).
-var functionMatcher = regexp.MustCompile("^/?function/([^/?]+)([^?]*)")
+var functionMatcher = regexp.MustCompile("^/?(?:async-)?function/([^/?]+)([^?]*)")
 
 // HTTPNotifier notify about HTTP request/response
 type HTTPNotifier interface {

--- a/gateway/handlers/forwarding_proxy_test.go
+++ b/gateway/handlers/forwarding_proxy_test.go
@@ -164,7 +164,10 @@ func Test_buildUpstreamRequest_Body_Method_Query_Path(t *testing.T) {
 		t.Fail()
 	}
 
-	upstream := buildUpstreamRequest(request, "http://xyz:8080", request.URL.Path)
+	transformer := FunctionPrefixTrimmingURLPathTransformer{}
+	transformedPath := transformer.Transform(request)
+
+	upstream := buildUpstreamRequest(request, "http://xyz:8080", transformedPath)
 
 	if request.Method != upstream.Method {
 		t.Errorf("Method - want: %s, got: %s", request.Method, upstream.Method)

--- a/gateway/handlers/queueproxy.go
+++ b/gateway/handlers/queueproxy.go
@@ -15,7 +15,7 @@ import (
 )
 
 // MakeQueuedProxy accepts work onto a queue
-func MakeQueuedProxy(metrics metrics.MetricOptions, wildcard bool, canQueueRequests queue.CanQueueRequests) http.HandlerFunc {
+func MakeQueuedProxy(metrics metrics.MetricOptions, wildcard bool, canQueueRequests queue.CanQueueRequests, pathTransformer URLPathTransformer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
@@ -49,6 +49,7 @@ func MakeQueuedProxy(metrics metrics.MetricOptions, wildcard bool, canQueueReque
 			Body:        body,
 			Method:      r.Method,
 			QueryString: r.URL.RawQuery,
+			Path:        pathTransformer.Transform(r),
 			Header:      r.Header,
 			Host:        r.Host,
 			CallbackURL: callbackURL,

--- a/gateway/queue/types.go
+++ b/gateway/queue/types.go
@@ -12,6 +12,7 @@ type Request struct {
 	Host        string
 	Body        []byte
 	Method      string
+	Path        string
 	QueryString string
 	Function    string
 	CallbackURL *url.URL `json:"CallbackUrl"`

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -74,7 +74,7 @@ func main() {
 		functionURLResolver = urlResolver
 	}
 
-	urlTransformer := handlers.PathTruncatingURLPathTransformer{}
+	urlTransformer := handlers.FunctionPathTruncatingURLPathTransformer{}
 	var functionURLTransformer handlers.URLPathTransformer
 
 	if config.PassURLPathsToFunctions {

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -135,6 +135,7 @@ func main() {
 	// r.StrictSlash(false)	// This didn't work, so register routes twice.
 	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}", functionProxy)
 	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/", functionProxy)
+	r.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/{params:.*}", faasHandlers.Proxy)
 
 	r.HandleFunc("/system/info", handlers.MakeInfoHandler(handlers.MakeForwardingProxyHandler(
 		reverseProxy, forwardingNotifiers, urlResolver))).Methods(http.MethodGet)
@@ -151,6 +152,7 @@ func main() {
 	if faasHandlers.QueuedProxy != nil {
 		r.HandleFunc("/async-function/{name:[-a-zA-Z_0-9]+}/", faasHandlers.QueuedProxy).Methods(http.MethodPost)
 		r.HandleFunc("/async-function/{name:[-a-zA-Z_0-9]+}", faasHandlers.QueuedProxy).Methods(http.MethodPost)
+		r.HandleFunc("/async-function/{name:[-a-zA-Z_0-9]+}/{params:.*}", faasHandlers.QueuedProxy).Methods(http.MethodPost)
 
 		r.HandleFunc("/system/async-report", faasHandlers.AsyncReport)
 	}

--- a/gateway/types/readconfig.go
+++ b/gateway/types/readconfig.go
@@ -105,6 +105,8 @@ func (ReadConfig) Read(hasEnv HasEnv) GatewayConfig {
 	cfg.DirectFunctions = parseBoolValue(hasEnv.Getenv("direct_functions"))
 	cfg.DirectFunctionsSuffix = hasEnv.Getenv("direct_functions_suffix")
 
+	cfg.PassURLPathsToFunctions = parseBoolValue(hasEnv.Getenv("pass_url_path_to_functions"))
+
 	cfg.UseBasicAuth = parseBoolValue(hasEnv.Getenv("basic_auth"))
 
 	secretPath := hasEnv.Getenv("secret_mount_path")
@@ -149,6 +151,10 @@ type GatewayConfig struct {
 
 	// If set this will be used to resolve functions directly
 	DirectFunctionsSuffix string
+
+	// If set to true, the requested path will be passed along to the function, minus the "/function/xyz"
+	// prefix, else the path will be truncated to "/" regardless of what the client sends.
+	PassURLPathsToFunctions bool
 
 	// If set, reads secrets from file-system for enabling basic auth.
 	UseBasicAuth bool


### PR DESCRIPTION
An implementation of proposal #716, passing the full URL through the Gateway and watchdog.

## Description

Previous to these changes, only the query string provide by the HTTP client was passed through to the handling code.  With these changes, the full URL path is passed as well as the query string.

## Motivation and Context
- [X] I have raised an issue to propose this change

Proposal #716 

## How Has This Been Tested?

A new automated test case has been added for the Gateway and for fwatchdog as well as manual testing.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

It is unlikely this is a breaking change.  Since the path is not currently passed by the Gateway, no existing function code can be relying on it.  Or more correctly, for there to be a problem, the code would have to be relying on the _absence_ of the path, which is unlikely though not completely impossible.

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

This may or may not require a documentation change.  The existing documentation, AFAIK, does not address the use of paths one way or the other.

## Refs

Trello: https://trello.com/c/1qZMlGXU