### PR TITLE
Add ewilde to .DEREK.yml maintainers list

### DIFF
--- a/.DEREK.yml
+++ b/.DEREK.yml
@@ -14,6 +14,7 @@ maintainers:
  - affix
  - viveksyngh
  - martindekov
+ - ewilde
 
 features:
  - dco_check


### PR DESCRIPTION
As suggested by @alexellis in https://github.com/openfaas/faas-cli/issues/436#issuecomment-409965422 i've added my github handle to the maintainers array in `DEREK.yml`