### PR TITLE
Bump up faas-swarm to 0.4.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
             - "/var/run/docker.sock:/var/run/docker.sock"
         # ports:
             # - 8081:8080
-        image:  openfaas/faas-swarm:0.4.0
+        image:  openfaas/faas-swarm:0.4.1
         networks:
             - functions
         environment:


### PR DESCRIPTION
This updates faas-swarm version including a fix for annotations.
In version 0.4.0 the prefix was not removed from the annotation
key, which was causing errors trying to get the value

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

Tested with [kafka-connector/pull/6](https://github.com/openfaas-incubator/kafka-connector/pull/6)