### PR TITLE
Propagate Host header from gateway request to the function.

### DIFF
--- a/gateway/handlers/forwarding_proxy.go
+++ b/gateway/handlers/forwarding_proxy.go
@@ -53,6 +53,9 @@ func buildUpstreamRequest(r *http.Request, url string) *http.Request {
 	}
 
 	upstreamReq, _ := http.NewRequest(r.Method, url, nil)
+	if len(r.Host) > 0 {
+		upstreamReq.Host = r.Host
+	}
 	copyHeaders(upstreamReq.Header, &r.Header)
 
 	upstreamReq.Header["X-Forwarded-For"] = []string{r.RemoteAddr}

--- a/gateway/handlers/forwarding_proxy_test.go
+++ b/gateway/handlers/forwarding_proxy_test.go
@@ -68,6 +68,40 @@ func Test_buildUpstreamRequest_NoBody_GetMethod_NoQuery(t *testing.T) {
 
 }
 
+func Test_buildUpstreamRequest_HasHostHeaderWhenSet(t *testing.T) {
+	srcBytes := []byte("hello world")
+
+	reader := bytes.NewReader(srcBytes)
+	request, err := http.NewRequest(http.MethodPost, "http://gateway/function?code=1", reader)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	upstream := buildUpstreamRequest(request, "/")
+
+	if request.Host != upstream.Host {
+		t.Errorf("Host - want: %s, got: %s", request.Host, upstream.Host)
+	}
+}
+
+func Test_buildUpstreamRequest_HostHeader_Empty_WhenNotSet(t *testing.T) {
+	srcBytes := []byte("hello world")
+
+	reader := bytes.NewReader(srcBytes)
+	request, err := http.NewRequest(http.MethodPost, "/function", reader)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	upstream := buildUpstreamRequest(request, "/")
+
+	if request.Host != upstream.Host {
+		t.Errorf("Host - want: %s, got: %s", request.Host, upstream.Host)
+	}
+}
+
 func Test_getServiceName(t *testing.T) {
 	scenarios := []struct {
 		name        string


### PR DESCRIPTION
Host HTTP header was not propagated to the function because it is not
a part of http.Request.Header map.
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR is described in issue https://github.com/openfaas-incubator/of-watchdog/issues/22

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
