### PR TITLE
Add X-Call-Id header to async function calls

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -95,6 +95,8 @@ func main() {
 
 		faasHandlers.QueuedProxy = handlers.MakeQueuedProxy(metricsOptions, true, natsQueue)
 		faasHandlers.AsyncReport = handlers.MakeAsyncReport(metricsOptions)
+
+		faasHandlers.QueuedProxy = handlers.MakeCallIDMiddleware(faasHandlers.QueuedProxy)
 	}
 
 	prometheusQuery := metrics.NewPrometheusQuery(config.PrometheusHost, config.PrometheusPort, &http.Client{})


### PR DESCRIPTION
This change allows getting X_Call_Id header with async call. With
non-async calls this is the default behaviour.  This change makes
it default for the async case as well.

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#813 

## How Has This Been Tested?

`asynctest/handler.py`:
```
import os

def handle(req):
    
    id_header = os.getenv("Http_X_Call_Id")

    return id_header
```
```
echo "" | faas invoke asynctest --async --header "X-Callback-Url=http://requestbin.fullcontact.com/1c9vjln1"
```
Result from `https://requestbin.fullcontact.com/1c9vjln1?inspect` with the change:
```
http://requestbin.fullcontact.com
POST /1c9vjln1  text/plain
 37 bytes 3m ago  
From 149.62.205.165, 70.132.17.50
FORM/POST PARAMETERS

None
HEADERS

Cloudfront-Is-Smarttv-Viewer: false
Connect-Time: 0
Cloudfront-Viewer-Country: BG
X-Request-Id: 71ed8fc3-a0e8-4d3c-9931-5875ade830dd
Content-Type: text/plain
User-Agent: Go-http-client/1.1
Date: Thu, 16 Aug 2018 11:34:24 GMT
Host: requestbin.fullcontact.com
Via: 1.1 29e0ad7ca7725f0240a0acc02cb16231.cloudfront.net (CloudFront), 1.1 vegur
Cloudfront-Is-Mobile-Viewer: false
Cloudfront-Forwarded-Proto: http
Connection: close
Cloudfront-Is-Desktop-Viewer: true
Total-Route-Time: 0
Content-Length: 37
Accept-Encoding: gzip
Cloudfront-Is-Tablet-Viewer: false
X-Amz-Cf-Id: gM0oOruw64fCM6aD0-_6H5rhWzxbKdjtwMM9tbWuWyajRWYOY8o9tA==
X-Duration-Seconds: 0.086637
RAW BODY

0df90097-c248-4df1-bdd3-d3ba95c5c0c3
```
and without
```
http://requestbin.fullcontact.com
POST /1c9vjln1  text/plain
 0 bytes 4s ago  
From 149.62.205.165, 70.132.1.160
FORM/POST PARAMETERS

None
HEADERS

Total-Route-Time: 0
Cloudfront-Is-Smarttv-Viewer: false
Connect-Time: 1
Cloudfront-Viewer-Country: BG
X-Request-Id: 86a5c35f-2a2c-4096-aa6a-cd9d03a7e45b
Content-Type: text/plain
User-Agent: Go-http-client/1.1
Date: Thu, 16 Aug 2018 11:38:02 GMT
Host: requestbin.fullcontact.com
Cloudfront-Is-Mobile-Viewer: false
Cloudfront-Forwarded-Proto: http
Connection: close
Cloudfront-Is-Desktop-Viewer: true
X-Duration-Seconds: 0.075293
Cloudfront-Is-Tablet-Viewer: false
Content-Length: 0
Accept-Encoding: gzip
X-Amz-Cf-Id: tyfI8SqXfP87iQkiTDoyWW1LWpbKn02JnMdF2L7x9XKN65SOkqcPQQ==
Via: 1.1 80c1ad5f9352d00b95a9da73eb6b6be5.cloudfront.net (CloudFront), 1.1 vegur
RAW BODY

None
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.