### PR TITLE
Added unit test for Host header propagation for asynchronous invocations

### DIFF
--- a/gateway/handlers/queueproxy_test.go
+++ b/gateway/handlers/queueproxy_test.go
@@ -1,0 +1,112 @@
+package handlers
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/openfaas/faas/gateway/metrics"
+	"github.com/openfaas/faas/gateway/queue"
+)
+
+// Dummy queue for saving only a single element
+type SingletonRequestQueue struct {
+	request **queue.Request
+}
+
+func (q SingletonRequestQueue) Queue(req *queue.Request) error {
+	if q.request == nil {
+		return errors.New("SingletonRequestQueue is not initialized")
+	}
+	*q.request = req
+	return nil
+}
+
+func (q SingletonRequestQueue) GetRequest() (*queue.Request, error) {
+	if q.request == nil {
+		return nil, errors.New("SingletonRequestQueue is not initialized")
+	}
+	return *q.request, nil
+}
+
+func Test_MakeQueuedProxy(t *testing.T) {
+	rr := httptest.NewRecorder()
+	srcBytes := []byte("hello world")
+	funcName := "testfunc"
+	reader := bytes.NewReader(srcBytes)
+	url := fmt.Sprintf("/function/%s/?code=1", funcName)
+	req, err := http.NewRequest(http.MethodPost, url, reader)
+	req.Header.Set("X-Source", "unit-test")
+	req.Header.Set("X-Callback-Url", "http://callback")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	metricsOptions := metrics.BuildMetricsOptions()
+	queue := SingletonRequestQueue{request: new(*queue.Request)}
+
+	router := mux.NewRouter()
+	functionProxy := func(w http.ResponseWriter, r *http.Request) {
+		proxyHandler := MakeQueuedProxy(metricsOptions, true, queue)
+		proxyHandler(w, r)
+	}
+	router.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}", functionProxy)
+	router.HandleFunc("/function/{name:[-a-zA-Z_0-9]+}/", functionProxy)
+	router.ServeHTTP(rr, req)
+
+	required := http.StatusAccepted
+	if status := rr.Code; status != required {
+		t.Errorf("handler returned wrong status code - got: %v, want: %v",
+			status, required)
+		t.Fatal()
+	}
+
+	queueReq, err := queue.GetRequest()
+
+	if queueReq == nil {
+		t.Errorf("Request in queue should not be nil")
+		t.Fail()
+	}
+
+	if funcName != queueReq.Function {
+		t.Errorf("Function name - want: %s, got: %s", funcName, queueReq.Function)
+		t.Fail()
+	}
+
+	if req.Method != queueReq.Method {
+		t.Errorf("Method - want: %s, got: %s", req.Method, queueReq.Method)
+		t.Fail()
+	}
+
+	if req.URL.RawQuery != queueReq.QueryString {
+		t.Errorf("QueryString - want: %s, got: %s", req.URL.RawQuery, queueReq.QueryString)
+		t.Fail()
+	}
+
+	if string(srcBytes) != string(queueReq.Body) {
+		t.Errorf("Body - want: %v, got: %v", string(srcBytes), string(queueReq.Body))
+		t.Fail()
+	}
+
+	if req.Host != queueReq.Host {
+		t.Errorf("Host - want: %s, got: %s", req.Host, queueReq.Host)
+		t.Fail()
+	}
+
+	if req.Header.Get("X-Source") != queueReq.Header.Get("X-Source") {
+		t.Errorf("Header X-Source - want: %s, got: %s", req.Header.Get("X-Source"), queueReq.Header.Get("X-Source"))
+		t.Fail()
+	}
+
+	if req.Header.Get("X-Callback-Url") != queueReq.CallbackURL.String() {
+		t.Errorf("Callback URL - want: %s, got: %s", req.Header.Get("X-Callback-Url"), queueReq.CallbackURL)
+		t.Fail()
+	}
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is follow-up fix for PR https://github.com/openfaas/faas/pull/816. It just adds an unit test. 

## Description
<!--- Describe your changes in detail -->
In this test I want to test conversion of `http.Request` to `queue.Request` performed by HTTP handler function returned by `MakeQueuedProxy`. In order to do this I create first mock queue struct `SingletonRequestQueue`, which implements `queue.CanQueueRequests` interface in order to pass it to `MakeQueuedProxy`.
I only need to store one single `queue.Request` instance in my queue, which I get back for comparison via `GetRequest` func. Since `queue.CanQueueRequests` is passed to `MakeQueuedProxy` by value I can't just store a pointer to `queue.Request`. Instead I create another level of indirection and store pointer to pointer to `queue.Request`. This require initialization of `SingletonRequestQueue` by allocating a pointer to `queue.Request`: `SingletonRequestQueue{request: new(*queue.Request)}` plus checks that queue is initialized in all accessing funcs.
Because I want to check that function name is correctly stored to `queue.Request` I need to create and initialize gorilla/mux router, for this I used an approach based on this https://github.com/quii/testing-gorillas .


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
