### PR TITLE
Added shell script which prints password used in openfaas deployed by deploy_stack.sh

### DIFF
--- a/get_password_from_stack.sh
+++ b/get_password_from_stack.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+CONTAINER=$(for f in $(docker service ps -q func_gateway); do
+                docker inspect --format '{{if eq .Status.State "running"}}{{.Status.ContainerStatus.ContainerID}}{{end}}' "$f";
+            done)
+if [ -z "$CONTAINER" ]; then
+    echo >&2 "No func_gateway container running"
+    exit 1
+fi
+
+docker exec -ti "$CONTAINER" /bin/sh -c 'cat /run/secrets/basic-auth-password'


### PR DESCRIPTION
## Description

## Motivation and Context
The documentation states how to get password from running openfaas but having a script is handy.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
