### PR TITLE
Adds support for PATCH HTTP verb in watchdog

### DIFF
--- a/watchdog/handler.go
+++ b/watchdog/handler.go
@@ -299,6 +299,7 @@ func makeRequestHandler(config *WatchdogConfig) func(http.ResponseWriter, *http.
 		case
 			http.MethodPost,
 			http.MethodPut,
+			http.MethodPatch,
 			http.MethodDelete,
 			http.MethodGet:
 			pipeRequest(config, w, r, r.Method)


### PR DESCRIPTION
## Description
All verbs used with REST APIs are now supported: "GET", "POST", "PUT",
"PATCH", "DELETE"

Part of : openfaas/faas#815

## Motivation and Context
- [x] I have raised an issue to propose this change openfaas/faas#815

## How Has This Been Tested?
### Feature testing
To test the new verbs I created a custom `Dockerfile` template with the new version of watchdog and deployed `envtest`

Below is the output when invoking the function using the new http verbs

#### PATCH
Note `Http_Method=PATCH` below

```
curl -X PATCH http://localhost:8080/function/env-test -i
HTTP/1.1 200 OK
Content-Length: 403
Content-Type: text/plain; charset=utf-8
Date: Sun, 19 Aug 2018 18:09:24 GMT
X-Call-Id: 0d6aee33-5a1d-4e30-8c37-602d4e340133
X-Duration-Seconds: 0.001461
X-Start-Time: 1534702164598405665

PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=9fcfbb9b0fd2
fprocess=env
HOME=/root
Http_User_Agent=curl/7.60.0
Http_Accept=*/*
Http_X_Call_Id=0d6aee33-5a1d-4e30-8c37-602d4e340133
Http_X_Forwarded_For=10.255.0.2:41812
Http_X_Start_Time=1534702164598405665
Http_Accept_Encoding=gzip
Http_Method=PATCH
Http_ContentLength=0
Http_Path=/function/env-test
Http_Host=localhost:8080
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes. (in certifier/pull/10)
- [x] All new and existing tests passed.
