### PR TITLE
Automatically select 'Download' for store functions

### DIFF
--- a/gateway/assets/index.html
+++ b/gateway/assets/index.html
@@ -158,8 +158,8 @@
                                 <md-input-container class="md-block" flex-gt-sm>
                                     <md-radio-group ng-model="invocation.contentType" layout="row" layout-align="start center">
                                         <md-radio-button value="text" class="md-primary"> Text </md-radio-button>
-                                        <md-radio-button value="json"> JSON </md-radio-button>
-                                        <md-radio-button value="binary"> Download </md-radio-button>                                        
+                                        <md-radio-button value="json" class="md-primary"> JSON </md-radio-button>
+                                        <md-radio-button value="binary" class="md-primary"> Download </md-radio-button>                                        
                                     </md-radio-group>
                                 </md-input-container>
                             </div>

--- a/gateway/assets/script/bootstrap.js
+++ b/gateway/assets/script/bootstrap.js
@@ -225,7 +225,11 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$interval', '$f
                 $scope.invocationResponse = "";
                 $scope.invocationStatus = "";
                 $scope.invocationInProgress = false;
-                $scope.invocation.contentType = "text";
+                if (fn.labels && fn.labels['com.openfaas.ui.ext']) {
+                  $scope.invocation.contentType = "binary";
+                } else {
+                  $scope.invocation.contentType = "text";
+                }
                 $scope.invocation.roundTripDuration = "";
             }
         };


### PR DESCRIPTION
Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This minor fix selects the 'Download' radio button by default if the function has a label with `com.openfaas.ui.ext`. This will improve the UX for people who use the function store.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#827 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Function with `com.openfaas.ui.ext` label**

1. Deploy the QRCode function which has the `com.openfaas.ui.ext` label.
2. Select the function from the list.
3. Check that the `Download` button is selected by default.

**Function without `com.openfaas.ui.ext` label**

1. Deploy the Figlet function which doesn't have the `com.openfaas.ui.ext` label.
2. Select the function from the list.
3. Check that the `Text` button is selected by default (not the Download button).

Tested with:

* Chrome
* Safari
* Firefox
* Edge
* IE11

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
