### PR TITLE
Update Swagger scaling edpoint docs to POST

### DIFF
--- a/api-docs/swagger.yml
+++ b/api-docs/swagger.yml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   description: OpenFaaS API documentation
-  version: 0.8.9
+  version: 0.8.12
   title: OpenFaaS API Gateway
   license:
     name: MIT
@@ -209,7 +209,7 @@ paths:
         '500':
           description: Internal server error
   '/system/scale-function/{functionName}':
-    get:
+    post:
       summary: Scale a function
       parameters:
       - in: path


### PR DESCRIPTION
The scaling endpoint supports POST method, but in Swagger it was
documented with GET instead. Also bumped up the gateway version
to 0.8.12

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

Resolves #835 