### PR TITLE
Bump Prometheus & AlertManager

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
 
     nats:
         image: nats-streaming:0.6.0
-        # Uncomment the following port mappings if you wish to expose the 
+        # Uncomment the following port mappings if you wish to expose the
         # NATS client and/or management ports
         # ports:
         #     - 4222:4222
@@ -112,7 +112,7 @@ services:
     # Start monitoring
 
     prometheus:
-        image: prom/prometheus:v2.2.0
+        image: prom/prometheus:v2.3.1
         environment:
             no_proxy: "gateway"
         configs:
@@ -139,7 +139,7 @@ services:
                     memory: 200M
 
     alertmanager:
-        image: prom/alertmanager:v0.15.0-rc.0
+        image: prom/alertmanager:v0.15.0
         environment:
             no_proxy: "gateway"
         command:
@@ -158,7 +158,7 @@ services:
                 reservations:
                     memory: 20M
             placement:
-                constraints: 
+                constraints:
                     - 'node.role == manager'
                     - 'node.platform.os == linux'
         configs:


### PR DESCRIPTION
Updated Swarm image versions for Prometheus &
Alertmanager to match Kubernetes stack

- Prometheus: v2.2.0 => v2.3.1
- Alertmanager: v0.15.0-rc.0 => v0.15.0

Signed-off-by: Patricio Diaz <padiazg@gmail.com>