### PR TITLE
radoslav/sample functions - Use curl instead of ADD for getting the watchdog

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -35,7 +35,7 @@ RUN go get github.com/microcosm-cc/bluemonday && \
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-ADD https://github.com/openfaas/faas/releases/download/0.8.0/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 ENV fprocess="/go/src/app/app"
@@ -61,7 +61,7 @@ Update the Docker stack with this:
 ```
 FROM alpine:latest
 
-ADD https://github.com/openfaas/faas/releases/download/0.8.0/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 ENV fprocess="wc"
@@ -78,7 +78,23 @@ Update your Docker stack with this definition:
         networks:
             - functions
         environment:
-            fprocess:	"wc"
+            fprocess: "wc"
+```
+
+**Tip:**
+You can optimize Docker to cache getting the watchdog by using curl, instead of ADD.
+To do so, replace the related lines with:
+```
+RUN apt-get update && apt-get install -y curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+```
+or with the following for Alpine based images:
+```
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 ```
 
 ### Testing your function

--- a/sample-functions/AlpineFunction/Dockerfile
+++ b/sample-functions/AlpineFunction/Dockerfile
@@ -1,9 +1,8 @@
 FROM alpine:3.7
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-
-# COPY ./fwatchdog /usr/bin/
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 # Populate example here
 # ENV fprocess="wc -l"

--- a/sample-functions/AlpineFunction/Dockerfile.arm64
+++ b/sample-functions/AlpineFunction/Dockerfile.arm64
@@ -1,8 +1,8 @@
-FROM arm64v8/alpine:3.7
+FROM alpine:3.7
 
-ADD https://github.com/alexellis/faas/releases/download/0.9.0/fwatchdog-arm64 /usr/bin/fwatchdog
-# COPY ./fwatchdog /usr/bin/
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog-arm64 > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 # Populate example here
 # ENV fprocess="wc -l"

--- a/sample-functions/AlpineFunction/Dockerfile.armhf
+++ b/sample-functions/AlpineFunction/Dockerfile.armhf
@@ -1,7 +1,8 @@
 FROM alpine:3.7
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog-armhf /usr/bin/fwatchdog
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog-armhf > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 # Populate example here
 # ENV fprocess="wc -l"

--- a/sample-functions/BaseFunctions/R/Dockerfile
+++ b/sample-functions/BaseFunctions/R/Dockerfile
@@ -1,7 +1,8 @@
 FROM artemklevtsov/r-alpine:latest
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 WORKDIR /root/
 

--- a/sample-functions/BaseFunctions/cobol/Dockerfile
+++ b/sample-functions/BaseFunctions/cobol/Dockerfile
@@ -1,7 +1,9 @@
 FROM toricls/gnucobol:latest
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
+RUN apt-get update && apt-get install -y curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /root/
 

--- a/sample-functions/BaseFunctions/coffee/Dockerfile
+++ b/sample-functions/BaseFunctions/coffee/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:6.9.1-alpine
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 WORKDIR /root/
 

--- a/sample-functions/BaseFunctions/dncore/Dockerfile
+++ b/sample-functions/BaseFunctions/dncore/Dockerfile
@@ -1,7 +1,9 @@
 FROM microsoft/dotnet:sdk
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
+RUN apt-get update && apt-get install -y curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
 

--- a/sample-functions/BaseFunctions/golang/Dockerfile
+++ b/sample-functions/BaseFunctions/golang/Dockerfile
@@ -8,8 +8,9 @@ COPY . /go/src/github.com/openfaas/faas/sample-functions/golang
 
 RUN go install
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 ENV fprocess "/go/bin/golang"
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1

--- a/sample-functions/BaseFunctions/java/Dockerfile
+++ b/sample-functions/BaseFunctions/java/Dockerfile
@@ -1,7 +1,8 @@
 FROM openjdk:8u121-jdk-alpine
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 WORKDIR /root/
 

--- a/sample-functions/BaseFunctions/node/Dockerfile
+++ b/sample-functions/BaseFunctions/node/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:6.9.1-alpine
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
-
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 WORKDIR /root/
 
 COPY package.json .

--- a/sample-functions/BaseFunctions/python/Dockerfile
+++ b/sample-functions/BaseFunctions/python/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:2.7-alpine
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 WORKDIR /root/
 

--- a/sample-functions/CaptainsIntent/Dockerfile
+++ b/sample-functions/CaptainsIntent/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:3.7
 RUN apk --update add nodejs nodejs-npm
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 COPY package.json   .
 COPY handler.js     .

--- a/sample-functions/ChangeColorIntent/Dockerfile
+++ b/sample-functions/ChangeColorIntent/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.7
 RUN apk --update add nodejs nodejs-npm
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-#COPY ./fwatchdog /usr/bin/
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 COPY package.json           .
 RUN npm i

--- a/sample-functions/HostnameIntent/Dockerfile
+++ b/sample-functions/HostnameIntent/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:3.7
 RUN apk --update add nodejs nodejs-npm
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 COPY package.json   .
 COPY handler.js     .

--- a/sample-functions/NodeInfo/Dockerfile
+++ b/sample-functions/NodeInfo/Dockerfile
@@ -2,8 +2,9 @@ FROM alpine:3.7
 
 RUN apk --update add nodejs nodejs-npm
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 COPY package.json .
 COPY main.js .

--- a/sample-functions/NodeInfo/Dockerfile.arm64
+++ b/sample-functions/NodeInfo/Dockerfile.arm64
@@ -1,9 +1,10 @@
-FROM arm64v8/alpine:3.7
+FROM alpine:3.7
 
 RUN apk --update add nodejs nodejs-npm
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog-arm64 /usr/bin/fwatchdog
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog-arm64 > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 COPY package.json .
 COPY main.js .

--- a/sample-functions/NodeInfo/Dockerfile.armhf
+++ b/sample-functions/NodeInfo/Dockerfile.armhf
@@ -1,8 +1,9 @@
 FROM alpine:3.7
 RUN apk --no-cache add nodejs nodejs-npm
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog-armhf /usr/bin/fwatchdog
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog-armhf > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 COPY package.json .
 COPY main.js .

--- a/sample-functions/Phantomjs/Dockerfile
+++ b/sample-functions/Phantomjs/Dockerfile
@@ -1,7 +1,9 @@
 FROM alexellis2/phantomjs-docker:latest
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
+RUN apt-get update && apt-get install -y curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV fprocess="phantomjs /dev/stdin"
 

--- a/sample-functions/ResizeImageMagick/Dockerfile
+++ b/sample-functions/ResizeImageMagick/Dockerfile
@@ -1,7 +1,8 @@
 FROM v4tech/imagemagick
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 ENV fprocess "convert - -resize 50% fd:1"
 

--- a/sample-functions/ResizeImageMagick/Dockerfile.armhf
+++ b/sample-functions/ResizeImageMagick/Dockerfile.armhf
@@ -2,8 +2,9 @@ FROM arm32v6/alpine:3.7
 
 RUN apk --no-cache add imagemagick
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog-armhf /usr/bin/fwatchdog
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog-armhf > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 ENV fprocess "convert - -resize 50% fd:1"
 

--- a/sample-functions/SentimentAnalysis/Dockerfile
+++ b/sample-functions/SentimentAnalysis/Dockerfile
@@ -3,8 +3,9 @@ FROM python:2.7-alpine
 RUN pip install textblob && \
     python -m textblob.download_corpora
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 WORKDIR /root/
 

--- a/sample-functions/SentimentAnalysis/Dockerfile.armhf
+++ b/sample-functions/SentimentAnalysis/Dockerfile.armhf
@@ -3,8 +3,10 @@ FROM arm32v7/python:2.7-slim
 RUN pip install textblob && \
     python -m textblob.download_corpora
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog-armhf /usr/bin/fwatchdog
-RUN chmod +x /usr/bin/fwatchdog
+RUN apt-get update && apt-get install -y curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog-armhf > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /root/
 

--- a/sample-functions/figlet/Dockerfile
+++ b/sample-functions/figlet/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.7
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 RUN apk add --no-cache figlet
 

--- a/sample-functions/figlet/Dockerfile.armhf
+++ b/sample-functions/figlet/Dockerfile.armhf
@@ -1,7 +1,8 @@
 FROM alpine:3.7
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog-armhf /usr/bin/fwatchdog
-RUN chmod +x /usr/bin/fwatchdog
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog-armhf > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 
 RUN apk add --no-cache figlet
 

--- a/watchdog/README.md
+++ b/watchdog/README.md
@@ -36,13 +36,22 @@ Example Dockerfile for an `echo` function:
 ```
 FROM alpine:3.7
 
-ADD https://github.com/openfaas/faas/releases/download/0.8.0/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 # Define your binary here
 ENV fprocess="/bin/cat"
 
 CMD ["fwatchdog"]
+```
+
+**Tip:**
+You can optimize Docker to cache getting the watchdog by using curl, instead of ADD.
+To do so, replace the related lines with:
+```
+RUN apk --no-cache add curl \
+    && curl -sL https://github.com/openfaas/faas/releases/download/0.9.0/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
 ```
 
 **Implementing a health-check**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The following PR will enable all functions to use curl to get the watchdog since this can be cached by Docker.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md)) 

The issue related to this PR is https://github.com/openfaas/faas/issues/841

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The change implies only to the way watchdog is being get, so the verification was made by simply using docker build to build successfully each image for each architecture (where available). 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
