### PR TITLE
Add basic auth support for /system/async-report

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -119,8 +119,12 @@ func main() {
 			auth.DecorateWithBasicAuth(faasHandlers.ListFunctions, credentials)
 		faasHandlers.ScaleFunction =
 			auth.DecorateWithBasicAuth(faasHandlers.ScaleFunction, credentials)
-		faasHandlers.QueryFunction = auth.DecorateWithBasicAuth(faasHandlers.QueryFunction, credentials)
-		faasHandlers.InfoHandler = auth.DecorateWithBasicAuth(faasHandlers.InfoHandler, credentials)
+		faasHandlers.QueryFunction =
+			auth.DecorateWithBasicAuth(faasHandlers.QueryFunction, credentials)
+		faasHandlers.InfoHandler =
+			auth.DecorateWithBasicAuth(faasHandlers.InfoHandler, credentials)
+		faasHandlers.AsyncReport =
+			auth.DecorateWithBasicAuth(faasHandlers.AsyncReport, credentials)
 	}
 
 	r := mux.NewRouter()


### PR DESCRIPTION
This commit adds basic authentication for `/system/async-report`
endpoint.

It also adds basic-auth secrets to `queue-worker` service which will be
used for gateway calls to `/system/async-report`.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

This is required to fix https://github.com/openfaas/nats-queue-worker/issues/35 issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test results have been added here. 

https://github.com/openfaas/nats-queue-worker/pull/36

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
