### PR TITLE
Set upstream X-Forwarded Host and For headers if not present

### DIFF
--- a/gateway/handlers/forwarding_proxy.go
+++ b/gateway/handlers/forwarding_proxy.go
@@ -103,8 +103,6 @@ func forwardRequest(w http.ResponseWriter, r *http.Request, proxyClient *http.Cl
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	log.Printf("Upstream request to: %s, %+v\n", upstreamReq.URL.Path, upstreamReq)
-
 	res, resErr := proxyClient.Do(upstreamReq.WithContext(ctx))
 	if resErr != nil {
 		badStatus := http.StatusBadGateway

--- a/gateway/handlers/forwarding_proxy_test.go
+++ b/gateway/handlers/forwarding_proxy_test.go
@@ -72,7 +72,7 @@ func Test_buildUpstreamRequest_NoBody_GetMethod_NoQuery(t *testing.T) {
 
 }
 
-func Test_buildUpstreamRequest_HasHostHeaderWhenSet(t *testing.T) {
+func Test_buildUpstreamRequest_HasXForwardedHostHeaderWhenSet(t *testing.T) {
 	srcBytes := []byte("hello world")
 
 	reader := bytes.NewReader(srcBytes)
@@ -84,12 +84,12 @@ func Test_buildUpstreamRequest_HasHostHeaderWhenSet(t *testing.T) {
 
 	upstream := buildUpstreamRequest(request, "/", "/")
 
-	if request.Host != upstream.Host {
-		t.Errorf("Host - want: %s, got: %s", request.Host, upstream.Host)
+	if request.Host != upstream.Header.Get("X-Forwarded-Host") {
+		t.Errorf("Host - want: %s, got: %s", request.Host, upstream.Header.Get("X-Forwarded-Host"))
 	}
 }
 
-func Test_buildUpstreamRequest_HostHeader_Empty_WhenNotSet(t *testing.T) {
+func Test_buildUpstreamRequest_XForwardedHostHeader_Empty_WhenNotSet(t *testing.T) {
 	srcBytes := []byte("hello world")
 
 	reader := bytes.NewReader(srcBytes)
@@ -101,8 +101,8 @@ func Test_buildUpstreamRequest_HostHeader_Empty_WhenNotSet(t *testing.T) {
 
 	upstream := buildUpstreamRequest(request, "/", "/")
 
-	if request.Host != upstream.Host {
-		t.Errorf("Host - want: %s, got: %s", request.Host, upstream.Host)
+	if request.Host != upstream.Header.Get("X-Forwarded-Host") {
+		t.Errorf("Host - want: %s, got: %s", request.Host, upstream.Header.Get("X-Forwarded-Host"))
 	}
 }
 

--- a/gateway/handlers/forwarding_proxy_test.go
+++ b/gateway/handlers/forwarding_proxy_test.go
@@ -106,6 +106,24 @@ func Test_buildUpstreamRequest_XForwardedHostHeader_Empty_WhenNotSet(t *testing.
 	}
 }
 
+func Test_buildUpstreamRequest_XForwardedHostHeader_WhenAlreadyPresent(t *testing.T) {
+	srcBytes := []byte("hello world")
+	headerValue := "test.openfaas.com"
+	reader := bytes.NewReader(srcBytes)
+	request, err := http.NewRequest(http.MethodPost, "/function/test", reader)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request.Header.Set("X-Forwarded-Host", headerValue)
+	upstream := buildUpstreamRequest(request, "/", "/")
+
+	if upstream.Header.Get("X-Forwarded-Host") != headerValue {
+		t.Errorf("X-Forwarded-Host - want: %s, got: %s", headerValue, upstream.Header.Get("X-Forwarded-Host"))
+	}
+}
+
 func Test_getServiceName(t *testing.T) {
 	scenarios := []struct {
 		name        string


### PR DESCRIPTION
## Description

This PR does the following:
*  Fix #847 by removing the http client host override
* X-Forwarded-For and X-Forwarded-Host are usually handled by the ingress controller, if those headers are not set then the gateway will create them

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Tested using `stefanprodan/of-env:1.0.0`locally and on GKE with Istio ingress gateway.

Http_X_Forwarded_For was `127.0.0.1:44238` and after the patch it shows the real IP of the caller.

Http_X_Forwarded_Host is set by the gateway when no reverse proxy sets it first.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.