### PR TITLE
Enable basic auth for service query / scaling on provider

### DIFF
--- a/gateway/metrics/exporter.go
+++ b/gateway/metrics/exporter.go
@@ -14,6 +14,7 @@ import (
 
 	"log"
 
+	"github.com/openfaas/faas-provider/auth"
 	"github.com/openfaas/faas/gateway/requests"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -22,13 +23,15 @@ import (
 type Exporter struct {
 	metricOptions MetricOptions
 	services      []requests.Function
+	credentials   *auth.BasicAuthCredentials
 }
 
 // NewExporter creates a new exporter for the OpenFaaS gateway metrics
-func NewExporter(options MetricOptions) *Exporter {
+func NewExporter(options MetricOptions, credentials *auth.BasicAuthCredentials) *Exporter {
 	return &Exporter{
 		metricOptions: options,
 		services:      []requests.Function{},
+		credentials:   credentials,
 	}
 }
 
@@ -77,6 +80,9 @@ func (e *Exporter) StartServiceWatcher(endpointURL url.URL, metricsOptions Metri
 			case <-ticker.C:
 
 				get, _ := http.NewRequest(http.MethodGet, endpointURL.String()+"system/functions", nil)
+				if e.credentials != nil {
+					get.SetBasicAuth(e.credentials.User, e.credentials.Password)
+				}
 
 				services := []requests.Function{}
 				res, err := proxyClient.Do(get)

--- a/gateway/metrics/exporter_test.go
+++ b/gateway/metrics/exporter_test.go
@@ -33,7 +33,7 @@ func readGauge(g prometheus.Metric) metricResult {
 
 func Test_Describe_DescribesThePrometheusMetrics(t *testing.T) {
 	metricsOptions := BuildMetricsOptions()
-	exporter := NewExporter(metricsOptions)
+	exporter := NewExporter(metricsOptions, nil)
 
 	ch := make(chan *prometheus.Desc)
 	defer close(ch)
@@ -62,7 +62,7 @@ func Test_Describe_DescribesThePrometheusMetrics(t *testing.T) {
 
 func Test_Collect_CollectsTheNumberOfReplicasOfAService(t *testing.T) {
 	metricsOptions := BuildMetricsOptions()
-	exporter := NewExporter(metricsOptions)
+	exporter := NewExporter(metricsOptions, nil)
 
 	expectedService := requests.Function{
 		Name:     "function_with_two_replica",

--- a/gateway/metrics/prometheus_query.go
+++ b/gateway/metrics/prometheus_query.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 )
 
-// PrometheusQuery a PrometheusQuery
+// PrometheusQuery represents parameters for querying Prometheus
 type PrometheusQuery struct {
 	Port   int
 	Host   string

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -53,7 +53,7 @@ func main() {
 	servicePollInterval := time.Second * 5
 
 	metricsOptions := metrics.BuildMetricsOptions()
-	exporter := metrics.NewExporter(metricsOptions)
+	exporter := metrics.NewExporter(metricsOptions, credentials)
 	exporter.StartServiceWatcher(*config.FunctionsProviderURL, metricsOptions, "func", servicePollInterval)
 	metrics.RegisterExporter(exporter)
 
@@ -89,7 +89,7 @@ func main() {
 	faasHandlers.QueryFunction = handlers.MakeForwardingProxyHandler(reverseProxy, forwardingNotifiers, urlResolver, nilURLTransformer)
 	faasHandlers.InfoHandler = handlers.MakeInfoHandler(handlers.MakeForwardingProxyHandler(reverseProxy, forwardingNotifiers, urlResolver, nilURLTransformer))
 
-	alertHandler := plugin.NewExternalServiceQuery(*config.FunctionsProviderURL)
+	alertHandler := plugin.NewExternalServiceQuery(*config.FunctionsProviderURL, credentials)
 	faasHandlers.Alert = handlers.MakeAlertHandler(alertHandler)
 
 	if config.UseNATS() {


### PR DESCRIPTION
Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Enable basic auth for service query / scaling on provider

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

- this is a blocking issue for auth with Docker Swarm
fixes #879

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with Swarm along with @LucasRoesler verifying the results

gateway_service_count is now added back to the metrics and the auto-scaling is now working for Swarm because auth is available to pass to the provider.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Workaround

In lieu of updating to a new release users can turn off `basic_auth` in `docker-compose.yml` for the faas-provider component. I also published `0.9.5-rc2` as a temporary tag for the gateway. 
