### PR TITLE
Add checking for existent function in GetReplicas

### DIFF
--- a/gateway/handlers/function_cache_test.go
+++ b/gateway/handlers/function_cache_test.go
@@ -73,3 +73,43 @@ func Test_CacheGivesHitWithLongExpiry(t *testing.T) {
 		t.Errorf("hit, want: %v, got %v", wantHit, hit)
 	}
 }
+
+func Test_CacheFunctionExists(t *testing.T) {
+	fnName := "echo"
+
+	cache := FunctionCache{
+		Cache:  make(map[string]*FunctionMeta),
+		Expiry: time.Millisecond * 10,
+	}
+
+	cache.Set(fnName, ServiceQueryResponse{AvailableReplicas: 1})
+	time.Sleep(time.Millisecond * 2)
+
+	_, hit := cache.Get(fnName)
+
+	wantHit := true
+
+	if hit != wantHit {
+		t.Errorf("hit, want: %v, got %v", wantHit, hit)
+	}
+}
+func Test_CacheFunctionNotExist(t *testing.T) {
+	fnName := "echo"
+	testName := "burt"
+
+	cache := FunctionCache{
+		Cache:  make(map[string]*FunctionMeta),
+		Expiry: time.Millisecond * 10,
+	}
+
+	cache.Set(fnName, ServiceQueryResponse{AvailableReplicas: 1})
+	time.Sleep(time.Millisecond * 2)
+
+	_, hit := cache.Get(testName)
+
+	wantHit := false
+
+	if hit != wantHit {
+		t.Errorf("hit, want: %v, got %v", wantHit, hit)
+	}
+}

--- a/gateway/handlers/scaling.go
+++ b/gateway/handlers/scaling.go
@@ -36,7 +36,6 @@ func MakeScalingHandler(next http.HandlerFunc, upstream http.HandlerFunc, config
 		}
 
 		queryResponse, err := config.ServiceQuery.GetReplicas(functionName)
-		cache.Set(functionName, queryResponse)
 
 		if err != nil {
 			var errStr string
@@ -47,6 +46,8 @@ func MakeScalingHandler(next http.HandlerFunc, upstream http.HandlerFunc, config
 			w.Write([]byte(errStr))
 			return
 		}
+
+		cache.Set(functionName, queryResponse)
 
 		if queryResponse.AvailableReplicas == 0 {
 			minReplicas := uint64(1)

--- a/gateway/handlers/scaling.go
+++ b/gateway/handlers/scaling.go
@@ -42,7 +42,7 @@ func MakeScalingHandler(next http.HandlerFunc, upstream http.HandlerFunc, config
 			errStr = fmt.Sprintf("error finding function %s: %s", functionName, err.Error())
 
 			log.Printf(errStr)
-			w.WriteHeader(http.StatusInternalServerError)
+			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte(errStr))
 			return
 		}

--- a/gateway/plugin/external.go
+++ b/gateway/plugin/external.go
@@ -61,6 +61,7 @@ type ScaleServiceRequest struct {
 // GetReplicas replica count for function
 func (s ExternalServiceQuery) GetReplicas(serviceName string) (handlers.ServiceQueryResponse, error) {
 	var err error
+	var emptyServiceQueryResponse handlers.ServiceQueryResponse
 
 	function := requests.Function{}
 
@@ -88,6 +89,8 @@ func (s ExternalServiceQuery) GetReplicas(serviceName string) (handlers.ServiceQ
 			if err != nil {
 				log.Println(urlPath, err)
 			}
+		} else {
+			return emptyServiceQueryResponse, fmt.Errorf("server returned non-200 status code (%d) for function, %s", res.StatusCode, serviceName)
 		}
 	}
 

--- a/gateway/plugin/external_test.go
+++ b/gateway/plugin/external_test.go
@@ -1,6 +1,15 @@
 package plugin
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/openfaas/faas-provider/auth"
+	"github.com/openfaas/faas/gateway/handlers"
+)
 
 const fallbackValue = 120
 
@@ -27,6 +36,104 @@ func TestLabelValueWasInValid(t *testing.T) {
 
 	if extractedValue != fallbackValue {
 		t.Log("Expected extractedValue to equal the fallbackValue")
+		t.Fail()
+	}
+}
+func TestGetReplicasNonExistentFn(t *testing.T) {
+
+	testServer := httptest.NewServer(
+		http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.WriteHeader(http.StatusNotFound)
+		}))
+	defer testServer.Close()
+
+	var creds auth.BasicAuthCredentials
+
+	url, _ := url.Parse(testServer.URL + "/")
+
+	esq := NewExternalServiceQuery(*url, &creds)
+
+	svcQryResp, err := esq.GetReplicas("burt")
+
+	if err == nil {
+		t.Logf("Error was nil, expected non-nil - the service query response value was %+v ", svcQryResp)
+		t.Fail()
+	}
+}
+
+func TestGetReplicasExistentFn(t *testing.T) {
+
+	testServer := httptest.NewServer(
+		http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.WriteHeader(http.StatusOK)
+			res.Write([]byte(`{"json":"body"}`))
+		}))
+	defer testServer.Close()
+
+	expectedSvcQryResp := handlers.ServiceQueryResponse{
+		Replicas:          0,
+		MaxReplicas:       uint64(handlers.DefaultMaxReplicas),
+		MinReplicas:       uint64(handlers.DefaultMinReplicas),
+		ScalingFactor:     uint64(handlers.DefaultScalingFactor),
+		AvailableReplicas: 0,
+	}
+
+	var creds auth.BasicAuthCredentials
+
+	url, _ := url.Parse(testServer.URL + "/")
+
+	esq := NewExternalServiceQuery(*url, &creds)
+
+	svcQryResp, err := esq.GetReplicas("burt")
+
+	if err != nil {
+		t.Logf("Expected err to be nil got: %s ", err.Error())
+		t.Fail()
+	}
+	if svcQryResp != expectedSvcQryResp {
+		t.Logf("Unexpected return values - wanted %+v, got: %+v ", expectedSvcQryResp, svcQryResp)
+		t.Fail()
+	}
+}
+
+func TestSetReplicasNonExistentFn(t *testing.T) {
+
+	testServer := httptest.NewServer(
+		http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.WriteHeader(http.StatusInternalServerError)
+		}))
+	defer testServer.Close()
+
+	var creds auth.BasicAuthCredentials
+	url, _ := url.Parse(testServer.URL + "/")
+	esq := NewExternalServiceQuery(*url, &creds)
+
+	err := esq.SetReplicas("burt", 1)
+
+	expectedErrStr := "error scaling HTTP code 500"
+
+	if !strings.Contains(err.Error(), expectedErrStr) {
+		t.Logf("Wanted string containing %s, got %s", expectedErrStr, err.Error())
+		t.Fail()
+	}
+}
+
+func TestSetReplicasExistentFn(t *testing.T) {
+
+	testServer := httptest.NewServer(
+		http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.WriteHeader(http.StatusOK)
+		}))
+	defer testServer.Close()
+
+	var creds auth.BasicAuthCredentials
+	url, _ := url.Parse(testServer.URL + "/")
+	esq := NewExternalServiceQuery(*url, &creds)
+
+	err := esq.SetReplicas("burt", 1)
+
+	if err != nil {
+		t.Logf("Expected err to be nil got: %s ", err.Error())
 		t.Fail()
 	}
 }


### PR DESCRIPTION
## Description

Within MakeScalingHandler() there is a call to GetReplicas() which was not returning an error when a non-200 http response was received from /system/function/.  The call would also return a populated struct, so the perception was that a function existed an had been scaled to zero.  This meant that the function would be added to the function cache and the code would continue into SetReplicas() where an attempt would be made to scale up a non-existent function.

This change amends GetReplicas() so that it will return an error if the gateway returns anything other than a 200 reponse code from the /system/function/ endpoint.  This causes MakeScalingHandler() to return earlier with an error indicating that the function could not be found.  The cache.Set call is also moved to after the error check so that the cache is only updated to include existent functions.

During investigations as to the cause of #876 tests were added to function_cache to check that Get() is behaving as intended when function exists and when not.  Tests are also added to `plugin/external.go` to test that GetReplicas() and SetReplicas() are following their intended modes of operation when 200 and non-200 responses are received from the gateway.

Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Motivation and Context
Error messages when attempting to access non-existent functions was suggesting a scaling event was being triggered and was failing.  The execution should have exited prior to this point.
- [x] I have raised an issue to propose this change (Fixes #876)

## How Has This Been Tested?
Unit tests added and confirmed as failing prior to fix. Post fix tests pass and travis is succeeding to build.

Deployed `rgee0/gateway:scaleFix2` onto a clean instance and confirmed scaling up and down occurs.

Confirmed requests for non-existent functions now return 404 via handling of the error out of GetReplicas().

```
of-router.1.powtmb5yiwfd@openfaas-20180922T110059    | Upstream http://gateway:8080/function/cloud-nodeinfo status: 200
of-router.1.powtmb5yiwfd@openfaas-20180922T110059    | Upstream http://gateway:8080/function/cloud-nodeinfo status: 200
of-router.1.powtmb5yiwfd@openfaas-20180922T110059    | Upstream http://gateway:8080/function/cloud-rgeee status: 404
of-router.1.powtmb5yiwfd@openfaas-20180922T110059    | Upstream http://gateway:8080/function/cloud-weeeeeee status: 404
of-router.1.powtmb5yiwfd@openfaas-20180922T110059    | Upstream http://gateway:8080/function/cloud-burt status: 404
```

Checked a function scaled to zero is treated as existing and scales up:
```
$ docker service ls | grep cloud-nodeinfo
tpjxr9bg7xh1        cloud-nodeinfo        replicated          0/0                 functions/nodeinfo:latest

$ curl -v http://cloud.technologee.co.uk/nodeinfo
*   Trying 178.128.175.206...
* TCP_NODELAY set
* Connected to cloud.technologee.co.uk (178.128.175.206) port 80 (#0)
> GET /nodeinfo HTTP/1.1
> Host: cloud.technologee.co.uk
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Length: 77
< Content-Type: text/plain; charset=utf-8
< Date: Sun, 23 Sep 2018 09:30:36 GMT
< X-Call-Id: 6cf012fa-a382-4266-96c5-ac3bc47e2b3b
< X-Duration-Seconds: 0.149956
< X-Start-Time: 1537695036326983743
< 
Hostname: 713a366ef394

Platform: linux
Arch: x64
CPU count: 2
Uptime: 80926
* Connection #0 to host cloud.technologee.co.uk left intact

$ docker service ls | grep cloud-nodeinfo
tpjxr9bg7xh1        cloud-nodeinfo        replicated          1/1                 functions/nodeinfo:latest

```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
