### PR TITLE
ARMHF publishing script - remove jq dependency

### DIFF
--- a/contrib/publish-armhf.sh
+++ b/contrib/publish-armhf.sh
@@ -35,7 +35,7 @@ do
    echo "Latest release: $TAG"
 
    REPOSITORY=$(get_repo_name $i)
-   TAG_PRESENT=$(curl -s "https://hub.docker.com/v2/repositories/${REPOSITORY}/tags/${TAG}-armhf/" | jq -r ".detail")
+   TAG_PRESENT=$(curl -s "https://hub.docker.com/v2/repositories/${REPOSITORY}/tags/${TAG}-armhf/" | grep -Po '"detail": *"[^"]*"' | grep -o 'Not found')
 
    if [ "$TAG_PRESENT" = "Not found" ]; then
        make ci-armhf-build ci-armhf-push


### PR DESCRIPTION
Signed-off-by: Radoslav Dimitrov <rdimitrow@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Avoided the `jq` dependency using `grep`. It still checks whether the `detail` pair has a value of `Not found` and based on that decides whether to build or not the ARMHF image.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
