### PR TITLE
Add new metrics for gateway function

### DIFF
--- a/gateway/handlers/forwarding_proxy.go
+++ b/gateway/handlers/forwarding_proxy.go
@@ -156,9 +156,36 @@ func (p PrometheusFunctionNotifier) Notify(method string, URL string, originalUR
 
 	code := strconv.Itoa(statusCode)
 
+	request_type := getRequestType(code)
+
 	p.Metrics.GatewayFunctionInvocation.
 		With(prometheus.Labels{"function_name": serviceName, "code": code}).
 		Inc()
+
+	p.Metrics.GatewayFunctionStatusIncovation.
+		With(prometheus.Labels{"function_name": serviceName, "code": code,
+			"request_type": request_type}).Observe(seconds)
+}
+
+func getRequestType(statusCode string) string {
+	statusType := string(statusCode[0])
+	var requestType string
+
+	switch statusType {
+	case "1":
+		requestType = "informational"
+	case "2":
+		requestType = "success"
+	case "3":
+		requestType = "redirection"
+	case "4":
+		requestType = "clientError"
+	case "5":
+		requestType = "internalServerError"
+	default:
+		requestType = statusType
+	}
+	return requestType
 }
 
 func getServiceName(urlValue string) string {

--- a/gateway/metrics/exporter.go
+++ b/gateway/metrics/exporter.go
@@ -40,12 +40,14 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	e.metricOptions.GatewayFunctionInvocation.Describe(ch)
 	e.metricOptions.GatewayFunctionsHistogram.Describe(ch)
 	e.metricOptions.ServiceReplicasGauge.Describe(ch)
+	e.metricOptions.GatewayFunctionStatusIncovation.Describe(ch)
 }
 
 // Collect collects data to be consumed by prometheus
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.metricOptions.GatewayFunctionInvocation.Collect(ch)
 	e.metricOptions.GatewayFunctionsHistogram.Collect(ch)
+	e.metricOptions.GatewayFunctionStatusIncovation.Collect(ch)
 
 	e.metricOptions.ServiceReplicasGauge.Reset()
 	for _, service := range e.services {

--- a/gateway/metrics/exporter_test.go
+++ b/gateway/metrics/exporter_test.go
@@ -58,6 +58,13 @@ func Test_Describe_DescribesThePrometheusMetrics(t *testing.T) {
 	if expectedServiceReplicasGaugeDesc != actualServiceReplicasGaugeDesc {
 		t.Errorf("Want %s, got: %s", expectedServiceReplicasGaugeDesc, actualServiceReplicasGaugeDesc)
 	}
+	d = (<-ch)
+	expectedGatewayFunctionStatusHistogramDesc := `Desc{fqName: "gateway_function_seconds_status", help: "Function time taken by status", constLabels: {}, variableLabels: [function_name code request_type]}`
+	actualGatewayFunctionStatusHistogram := d.String()
+	if expectedGatewayFunctionStatusHistogramDesc != actualGatewayFunctionStatusHistogram {
+		t.Errorf("Want %s, got: %s", expectedGatewayFunctionStatusHistogramDesc, actualGatewayFunctionStatusHistogram)
+	}
+
 }
 
 func Test_Collect_CollectsTheNumberOfReplicasOfAService(t *testing.T) {

--- a/gateway/metrics/metrics.go
+++ b/gateway/metrics/metrics.go
@@ -11,9 +11,10 @@ import (
 
 // MetricOptions to be used by web handlers
 type MetricOptions struct {
-	GatewayFunctionInvocation *prometheus.CounterVec
-	GatewayFunctionsHistogram *prometheus.HistogramVec
-	ServiceReplicasGauge      *prometheus.GaugeVec
+	GatewayFunctionInvocation       *prometheus.CounterVec
+	GatewayFunctionsHistogram       *prometheus.HistogramVec
+	ServiceReplicasGauge            *prometheus.GaugeVec
+	GatewayFunctionStatusIncovation *prometheus.HistogramVec
 }
 
 // PrometheusHandler Bootstraps prometheus for metrics collection
@@ -36,6 +37,14 @@ func BuildMetricsOptions() MetricOptions {
 		[]string{"function_name", "code"},
 	)
 
+	gatewayFunctionStatusHistogram := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "gateway_function_seconds_status",
+			Help: "Function time taken by status",
+		},
+		[]string{"function_name", "code", "request_type"},
+	)
+
 	serviceReplicas := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "gateway_service_count",
@@ -45,9 +54,10 @@ func BuildMetricsOptions() MetricOptions {
 	)
 
 	metricsOptions := MetricOptions{
-		GatewayFunctionsHistogram: gatewayFunctionsHistogram,
-		GatewayFunctionInvocation: gatewayFunctionInvocation,
-		ServiceReplicasGauge:      serviceReplicas,
+		GatewayFunctionsHistogram:       gatewayFunctionsHistogram,
+		GatewayFunctionInvocation:       gatewayFunctionInvocation,
+		ServiceReplicasGauge:            serviceReplicas,
+		GatewayFunctionStatusIncovation: gatewayFunctionStatusHistogram,
 	}
 
 	return metricsOptions


### PR DESCRIPTION
Currently no data flows to prometheus about which has data about the
response type of the functions being executed. This will allow users
to calculate the metrics like the following(and more):

1. Number of 1XX/2XX/3XX/4XX/5xx requests per second
2. Distribution of response time for requests

Fixes #703

Signed-off-by: avneesh91 <mightymosquito1991@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
I have added another histogram type which sends classified request type classified information about the function invocations. The current format is:

1XX: informational
2XX: success
3XX: redirect
4XX: clientError
5XX: internalServerError

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test under exporter_test.go

## Seeing metrics
I can make queries like:
rate(gateway_function_seconds_status_count{request_type="internalServerError"}[50m])/rate(gateway_function_seconds_status_sum{request_type="internalServerError"}[50m])

which will give me an average faliure rate of all the functions in the last 50mins.

or for specific functions:
rate(gateway_function_seconds_status_count{function_name="cow",request_type="internalServerError"}[50m])/rate(gateway_function_seconds_status_sum{function_name="cow",request_type="internalServerError"}[50m])

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
