### PR TITLE
Don't follow redirects from functions

### DIFF
--- a/gateway/tests/integration/createfunction_test.go
+++ b/gateway/tests/integration/createfunction_test.go
@@ -37,7 +37,7 @@ func TestCreate_ValidRequest(t *testing.T) {
 		t.Fail()
 	}
 
-	expectedErrorCode := http.StatusOK
+	expectedErrorCode := http.StatusAccepted
 	if code != expectedErrorCode {
 		t.Errorf("Got HTTP code: %d, want %d\n", code, expectedErrorCode)
 		return

--- a/gateway/types/proxy_client.go
+++ b/gateway/types/proxy_client.go
@@ -28,7 +28,11 @@ func NewHTTPClientReverseProxy(baseURL *url.URL, timeout time.Duration) *HTTPCli
 			ExpectContinueTimeout: 1500 * time.Millisecond,
 		},
 		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
+
 	return &h
 }
 


### PR DESCRIPTION
- Covers part of 919 by making the HTTP client used for proxying
stop following redirects. Tested with a stateless microservice,
but additional code changes may be requierd in the queue-worker,
the watchdogs and other areas.

Tested on Swarm with stateless microservice (Node.js) issuing
a redirect via Location header.

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>
