### PR TITLE
Add logging to scale from zero requests

### DIFF
--- a/gateway/handlers/scaling.go
+++ b/gateway/handlers/scaling.go
@@ -55,6 +55,9 @@ func MakeScalingHandler(next http.HandlerFunc, upstream http.HandlerFunc, config
 				minReplicas = queryResponse.MinReplicas
 			}
 
+			log.Printf("[Scale] function=%s 0 => %d requested", functionName, minReplicas)
+			scalingStartTime := time.Now()
+
 			err := config.ServiceQuery.SetReplicas(functionName, minReplicas)
 			if err != nil {
 				errStr := fmt.Errorf("unable to scale function [%s], err: %s", functionName, err)
@@ -79,6 +82,8 @@ func MakeScalingHandler(next http.HandlerFunc, upstream http.HandlerFunc, config
 				}
 
 				if queryResponse.AvailableReplicas > 0 {
+					scalingDuration := time.Since(scalingStartTime)
+					log.Printf("[Scale] function=%s 0 => %d successful - %f seconds", functionName, queryResponse.AvailableReplicas, scalingDuration.Seconds())
 					break
 				}
 


### PR DESCRIPTION
## Description
Adds logging around scale from zero events in scaling.go.  Previously scale from zero events were not logged in the same way that normal scaling events are.  This change adds log writes to show when a scale from zero was requested and when a function successfully moved to > 0 replicas.

## Motivation and Context
Recent testing of related changes highlighted a gap in the logging around scale from zero events.  They were not being logged in the same was as normal scaling events making it difficult to track down such events.
- [x] I have raised an issue to propose this change (Fixes #885)

## How Has This Been Tested?
Built the gateway image - rgee0/gateway:scaleLogging
Amended docker-compose.yml to enable scale from zero and changed the gateway image.
Ran `deploy_stack.sh`
Deployed `env` function
Ran `docker service scale env=0` and confrmed env had scaled to zero
```
ID                  NAME                MODE                REPLICAS            IMAGE                         PORTS
ebynlsqzgapb        env                 replicated          0/0                 functions/alpine:latest       
902uwzb8r96n        figlet              replicated          1/1                 functions/figlet:0.1          
xp34xsz72x7o        func_alertmanager   replicated          1/1                 prom/alertmanager:v0.15.0     
2qy4ssxm3b4l        func_faas-swarm     replicated          1/1                 openfaas/faas-swarm:0.4.4     
rrqdlrzz1y4y        func_gateway        replicated          1/1                 rgee0/gateway:scaleLogging    *:8080->8080/tcp
jic3tujjd56g        func_nats           replicated          1/1                 nats-streaming:0.6.0          
9kdenylcw23v        func_prometheus     replicated          1/1                 prom/prometheus:v2.3.1        *:9090->9090/tcp
1xajfiaskcza        func_queue-worker   replicated          1/1                 openfaas/queue-worker:0.5.4 
```
Ran `docker service logs -f func_gateway`
Ran `echo -n "" | faas invoke env`
Inspected logs for expected output

```
func_gateway.1.ttcvbgz8anwy@linuxkit-025000000001    | 2018/10/19 20:51:08 [Scale] function=env 0 => 1 requested
func_gateway.1.ttcvbgz8anwy@linuxkit-025000000001    | 2018/10/19 20:51:09 Forwarded [GET] to /system/functions - [200] - 0.005658 seconds
func_gateway.1.ttcvbgz8anwy@linuxkit-025000000001    | 2018/10/19 20:51:12 Forwarded [GET] to /system/functions - [200] - 0.007137 seconds
func_gateway.1.ttcvbgz8anwy@linuxkit-025000000001    | 2018/10/19 20:51:16 [Scale] function=env 0 => 1 successful - 8.009242 seconds
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Richard Gee <richard@technologee.co.uk>