### PR TITLE
Create user/pass secrets and add help/noAuth flags to deploy_stack.ps1

### DIFF
--- a/deploy_stack.ps1
+++ b/deploy_stack.ps1
@@ -1,44 +1,66 @@
 #!ps1
 
+param (
+    [switch] $noAuth,
+    [switch] $n
+)
+
 if (Get-Command docker -errorAction SilentlyContinue)
 {
     docker node ls 2>&1 | out-null
+    if(-Not $?)
+    {
+        throw "Docker not in swarm mode, please initialise the cluster (`docker swarm init`) and retry"
+    }
+
+    Add-Type -AssemblyName System.Web
+    $secret = [System.Web.Security.Membership]::GeneratePassword(24,5)
+    $user = 'admin'
+
+    Write-Host "Attempting to create credentials for gateway.."
+    $user_secret = "basic-auth-user"
+    docker secret inspect $user_secret 2>&1 | out-null
     if($?)
     {
-        $user_secret = "basic-auth-user"
-        docker secret inspect $user_secret 2>&1 | out-null
-        if($?)
-        {
-            Write-Host "$user_secret secret exists"
-        }
-        else
-        {
-            $user = Read-Host 'Admin User?'
-            $user | docker secret create $user_secret -
-        }
-
-        $password_secret = "basic-auth-password"
-        docker secret inspect $password_secret 2>&1 | out-null
-        if($?)
-        {
-            Write-Host "$password_secret secret exists"
-        }
-        else
-        {
-            $pass = Read-Host 'Password?' -AsSecureString
-            [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($pass)) | docker secret create $password_secret -
-        }
-
-        Write-Host "Deploying stack"
-        docker stack deploy func --compose-file ./docker-compose.yml
-    
+        Write-Host "$user_secret secret exists"
     }
     else
     {
-        Write-Host "Docker not in swarm mode, please initialise the cluster (`docker swarm init`) and retry"
+        $user | docker secret create $user_secret -
     }
+
+    $password_secret = "basic-auth-password"
+    docker secret inspect $password_secret 2>&1 | out-null
+    if($?)
+    {
+        Write-Host "$password_secret secret exists"
+    }
+    else
+    {
+        $secret | docker secret create $password_secret -
+        Write-Host "[Credentials]"
+        Write-Host " username: admin"
+        Write-Host " password: $secret"
+        Write-Host " Write-Output `"$secret`" | faas-cli login --username=$user --password-stdin"
+    }
+    
+    if ($noAuth -Or $n) {
+        Write-Host ""
+        Write-Host "Disabling basic authentication for gateway.."
+        Write-Host ""
+        $env:BASIC_AUTH="false";
+    }
+    else 
+    {
+        Write-Host ""
+        Write-Host "Enabling basic authentication for gateway.."
+        Write-Host ""
+    }
+
+    Write-Host "Deploying stack"
+    docker stack deploy func --compose-file ./docker-compose.yml
 }
 else
 {
-    Write-Host "Unable to find docker command, please install Docker (https://www.docker.com/) and retry"
+    throw "Unable to find docker command, please install Docker (https://www.docker.com/) and retry"
 }

--- a/deploy_stack.ps1
+++ b/deploy_stack.ps1
@@ -67,7 +67,7 @@ if (Get-Command docker -errorAction SilentlyContinue)
         Write-Host ""
     }
 
-    Write-Host "Deploying stack"
+    Write-Host "Deploying OpenFaaS core services"
     docker stack deploy func --compose-file ./docker-compose.yml
 }
 else

--- a/deploy_stack.ps1
+++ b/deploy_stack.ps1
@@ -2,8 +2,18 @@
 
 param (
     [switch] $noAuth,
-    [switch] $n
+    [switch] $n,
+    [switch] $help,
+    [switch] $h
 )
+
+if ($help -Or $h) {
+    Write-Host "Usage: "
+    Write-Host " [default]`tdeploy the OpenFaaS core services"
+    Write-Host " -noAuth [-n]`tdisable basic authentication"
+    Write-Host " -help [-h]`tdisplays this screen"
+    Exit
+}
 
 if (Get-Command docker -errorAction SilentlyContinue)
 {

--- a/deploy_stack.ps1
+++ b/deploy_stack.ps1
@@ -2,6 +2,31 @@
 
 if (Get-Command docker -errorAction SilentlyContinue)
 {
+
+    $user_secret = "basic-auth-user"
+    docker secret inspect $user_secret 2>&1 | out-null
+    if($?)
+    {
+        Write-Host "$user_secret secret exists"
+    }
+    else
+    {
+        $user = Read-Host 'Admin User?'
+        $user | docker secret create $user_secret -
+    }
+
+    $password_secret = "basic-auth-password"
+    docker secret inspect $password_secret 2>&1 | out-null
+    if($?)
+    {
+        Write-Host "$password_secret secret exists"
+    }
+    else
+    {
+        $pass = Read-Host 'Password?' -AsSecureString
+        [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($pass)) | docker secret create $password_secret -
+    }
+
     Write-Host "Deploying stack"
     docker stack deploy func --compose-file ./docker-compose.yml
 }

--- a/deploy_stack.ps1
+++ b/deploy_stack.ps1
@@ -36,7 +36,7 @@ if (Get-Command docker -errorAction SilentlyContinue)
     }
     else
     {
-        $user | docker secret create $user_secret -
+        $user | docker secret create $user_secret - | out-null
     }
 
     $password_secret = "basic-auth-password"
@@ -47,7 +47,7 @@ if (Get-Command docker -errorAction SilentlyContinue)
     }
     else
     {
-        $secret | docker secret create $password_secret -
+        $secret | docker secret create $password_secret - | out-null
         Write-Host "[Credentials]"
         Write-Host " username: admin"
         Write-Host " password: $secret"

--- a/deploy_stack.ps1
+++ b/deploy_stack.ps1
@@ -2,33 +2,41 @@
 
 if (Get-Command docker -errorAction SilentlyContinue)
 {
-
-    $user_secret = "basic-auth-user"
-    docker secret inspect $user_secret 2>&1 | out-null
+    docker node ls 2>&1 | out-null
     if($?)
     {
-        Write-Host "$user_secret secret exists"
+        $user_secret = "basic-auth-user"
+        docker secret inspect $user_secret 2>&1 | out-null
+        if($?)
+        {
+            Write-Host "$user_secret secret exists"
+        }
+        else
+        {
+            $user = Read-Host 'Admin User?'
+            $user | docker secret create $user_secret -
+        }
+
+        $password_secret = "basic-auth-password"
+        docker secret inspect $password_secret 2>&1 | out-null
+        if($?)
+        {
+            Write-Host "$password_secret secret exists"
+        }
+        else
+        {
+            $pass = Read-Host 'Password?' -AsSecureString
+            [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($pass)) | docker secret create $password_secret -
+        }
+
+        Write-Host "Deploying stack"
+        docker stack deploy func --compose-file ./docker-compose.yml
+    
     }
     else
     {
-        $user = Read-Host 'Admin User?'
-        $user | docker secret create $user_secret -
+        Write-Host "Docker not in swarm mode, please initialise the cluster (`docker swarm init`) and retry"
     }
-
-    $password_secret = "basic-auth-password"
-    docker secret inspect $password_secret 2>&1 | out-null
-    if($?)
-    {
-        Write-Host "$password_secret secret exists"
-    }
-    else
-    {
-        $pass = Read-Host 'Password?' -AsSecureString
-        [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($pass)) | docker secret create $password_secret -
-    }
-
-    Write-Host "Deploying stack"
-    docker stack deploy func --compose-file ./docker-compose.yml
 }
 else
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR updates the Windows `deploy_stack.ps1` Powershell script to set the `basic-auth-user` and generate the `basic-auth-password` secrets if absent.

It also adds the following flags:

- `-help`, `-h`: print help text
- `-noAuth`, `-n`: disable basic auth

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change (Closes #928)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed on Windows 10 with the following scenarios:
- No user or pass secret
- User secret exists, pass missing
- Pass secret exists, user missing
- Both user and pass secrets exist

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
