### PR TITLE
Update for scaling edge-case (fixes #931)

### DIFF
--- a/gateway/handlers/alerthandler.go
+++ b/gateway/handlers/alerthandler.go
@@ -5,11 +5,10 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
-
-	"fmt"
 
 	"github.com/openfaas/faas/gateway/requests"
 )
@@ -119,7 +118,7 @@ func CalculateReplicas(status string, currentReplicas uint64, maxReplicas uint64
 	newReplicas := currentReplicas
 	step := uint64((float64(maxReplicas) / 100) * float64(scalingFactor))
 
-	if status == "firing" {
+	if status == "firing" && step > 0 {
 		if currentReplicas == 1 {
 			newReplicas = step
 		} else {

--- a/gateway/handlers/alerthandler_test.go
+++ b/gateway/handlers/alerthandler_test.go
@@ -11,8 +11,8 @@ func TestDisabledScale(t *testing.T) {
 	minReplicas := uint64(1)
 	scalingFactor := uint64(0)
 	newReplicas := CalculateReplicas("firing", DefaultMinReplicas, DefaultMaxReplicas, minReplicas, scalingFactor)
-	if newReplicas != 0 {
-		t.Log("Expected not to scale")
+	if newReplicas != minReplicas {
+		t.Logf("Expected not to scale, but replicas were: %d", newReplicas)
 		t.Fail()
 	}
 }
@@ -23,6 +23,17 @@ func TestParameterEdge(t *testing.T) {
 	newReplicas := CalculateReplicas("firing", DefaultMinReplicas, DefaultMaxReplicas, minReplicas, scalingFactor)
 	if newReplicas != 0 {
 		t.Log("Expected not to scale")
+		t.Fail()
+	}
+}
+
+func TestScalingWithSameUpperLowerLimit(t *testing.T) {
+	minReplicas := uint64(1)
+	scalingFactor := uint64(20)
+	//	status string, currentReplicas uint64, maxReplicas uint64, minReplicas uint64, scalingFactor uint64)
+	newReplicas := CalculateReplicas("firing", minReplicas, minReplicas, minReplicas, scalingFactor)
+	if newReplicas != 1 {
+		t.Logf("Replicas - want: %d, got: %d", minReplicas, newReplicas)
 		t.Fail()
 	}
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As reported on Slack and in issue #931 the gateway scaling code
was scaling to zero replicas as a result of the "proportional
scaling" added by @Templum's PR.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#931 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This commit added a failing test
which was fixed by adding boundary checking - now if the scaling
amount is "0" we keep the current amount of replicas.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.