### PR TITLE
Enable backoff/retries on scaling up

### DIFF
--- a/gateway/scaling/scaling_config.go
+++ b/gateway/scaling/scaling_config.go
@@ -9,7 +9,8 @@ type ScalingConfig struct {
 	// MaxPollCount attempts to query a function before giving up
 	MaxPollCount uint
 
-	// FunctionPollInterval delay or interval between polling a function's readiness status
+	// FunctionPollInterval delay or interval between polling a function's
+	// readiness status
 	FunctionPollInterval time.Duration
 
 	// CacheExpiry life-time for a cache entry before considering invalid
@@ -17,4 +18,8 @@ type ScalingConfig struct {
 
 	// ServiceQuery queries available/ready replicas for function
 	ServiceQuery ServiceQuery
+
+	// SetScaleRetries is the number of times to try scaling a function before
+	// giving up due to errors
+	SetScaleRetries uint
 }

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -137,7 +137,8 @@ func main() {
 	if config.ScaleFromZero {
 		scalingConfig := scaling.ScalingConfig{
 			MaxPollCount:         uint(1000),
-			FunctionPollInterval: time.Millisecond * 10,
+			SetScaleRetries:      uint(20),
+			FunctionPollInterval: time.Millisecond * 50,
 			CacheExpiry:          time.Second * 5, // freshness of replica values before going stale
 			ServiceQuery:         alertHandler,
 		}


### PR DESCRIPTION
Enable backoff/retries on scaling up

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This change is needed for Docker Swarm which may give an error
when several concurrent requests come in to scale a deployment.

Docker will throw an error about being out of sync which could
have prevented some requests from being served.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

No issue is being raised, but this was found whilst working on
https://github.com/openfaas/nats-queue-worker/issues/32 with
high concurrency testing and watching the logs / completed
request count.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on Docker Swarm before/after with the hey tool and figlet
scaled down to zero replicas.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

