### PR TITLE
Update incubator link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For information on branding, the press-kit, registered entities and sponsorship 
 
 Looking for statistics? This project does not use a mono-repo, but is split across several components. Use [Ken Fukuyama's dashboard](https://kenfdev.o6s.io/github-stats-page) to gather accurate counts on contributors, stars and forks across the [GitHub organisation](https://github.com/openfaas).
 
-Incubator projects are not counted in these totals and are hosted under [openfaas-incubator](https://github.com/openfaas) awaiting graduation.
+Incubator projects are not counted in these totals and are hosted under [openfaas-incubator](https://github.com/openfaas-incubator) awaiting graduation.
 
 ### Governance
 


### PR DESCRIPTION
Incubator link is pointing to the main OpenFaaS GitHub organization instead of the OpenFaaS-Incubator organization. Lets see if this is signed off, if not I'll drop down from GitHub.com editing.

Signed-off-by: Shaun Berryman <shaun@shaunberryman.com>

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Did not raise an issue, discussed on Slack

## How Has This Been Tested?
Not required

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.