### PR TITLE
Add faasflow in the openfaas community reference

### DIFF
--- a/community.md
+++ b/community.md
@@ -292,6 +292,7 @@ You can also find cool projects or submit your own to the [faas-and-furious orga
 
 | Project name and description                                         | Author     | Site      | Date        |
 |----------------------------------------------------------------------|------------|-----------|-------------|
+| [Faasflow - faas workflow as a function](https://github.com/s8sg/faasflow) | Swarvanu Sengupta | github.com | 11-Nov-2018 |
 | [OpenFaaS Crystal Template](https://github.com/TPei/crystal_openfaas) | Thomas Peikert | github.com | 26-Oct-2018 |
 | [OpenFaaS Terraform Provider](https://github.com/ewilde/terraform-provider-openfaas) | Edward Wilde | github.com | 12-Oct-2018 |
 | [OpenFaaS Swift Template](https://github.com/affix/openfaas-swift-template) | Keiran Smith | github.com | 22-May-2018 |


### PR DESCRIPTION
Signed-off-by: Swarvanu Sengupta <swarvanusg@gmail.com>

Add [faasflow](https://github.com/s8sg/faasflow) reference in the openfaas community

## Description
Faasflow is library that allows to build openfaas workflow with ease and deploy it as a function, This changes add faasflow reference at `community.md` file

