### PR TITLE
Scaled up from 1

### DIFF
--- a/gateway/handlers/alerthandler.go
+++ b/gateway/handlers/alerthandler.go
@@ -100,14 +100,10 @@ func CalculateReplicas(status string, currentReplicas uint64, maxReplicas uint64
 	step := uint64((float64(maxReplicas) / 100) * float64(scalingFactor))
 
 	if status == "firing" && step > 0 {
-		if currentReplicas == 1 {
-			newReplicas = step
+		if currentReplicas+step > maxReplicas {
+			newReplicas = maxReplicas
 		} else {
-			if currentReplicas+step > maxReplicas {
-				newReplicas = maxReplicas
-			} else {
-				newReplicas = currentReplicas + step
-			}
+			newReplicas = currentReplicas + step
 		}
 	} else { // Resolved event.
 		newReplicas = minReplicas

--- a/gateway/handlers/alerthandler.go
+++ b/gateway/handlers/alerthandler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math"
 	"net/http"
 
 	"github.com/openfaas/faas/gateway/requests"
@@ -97,7 +98,7 @@ func scaleService(alert requests.PrometheusInnerAlert, service scaling.ServiceQu
 // CalculateReplicas decides what replica count to set depending on current/desired amount
 func CalculateReplicas(status string, currentReplicas uint64, maxReplicas uint64, minReplicas uint64, scalingFactor uint64) uint64 {
 	newReplicas := currentReplicas
-	step := uint64((float64(maxReplicas) / 100) * float64(scalingFactor))
+	step := uint64(math.Ceil(float64(maxReplicas) / 100 * float64(scalingFactor)))
 
 	if status == "firing" && step > 0 {
 		if currentReplicas+step > maxReplicas {

--- a/gateway/handlers/alerthandler_test.go
+++ b/gateway/handlers/alerthandler_test.go
@@ -110,3 +110,14 @@ func TestScaledUpFrom1(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestScaledUpWithSmallParam(t *testing.T) {
+	currentReplicas := uint64(1)
+	maxReplicas := uint64(4)
+	scalingFactor := uint64(1)
+	newReplicas := CalculateReplicas("firing", currentReplicas, maxReplicas, scaling.DefaultMinReplicas, scalingFactor)
+	if newReplicas == currentReplicas {
+		t.Log("Expected newReplicas > currentReplica")
+		t.Fail()
+	}
+}

--- a/gateway/handlers/alerthandler_test.go
+++ b/gateway/handlers/alerthandler_test.go
@@ -99,3 +99,14 @@ func TestBackingOff(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestScaledUpFrom1(t *testing.T) {
+	currentReplicas := uint64(1)
+	maxReplicas := uint64(5)
+	scalingFactor := uint64(30)
+	newReplicas := CalculateReplicas("firing", currentReplicas, maxReplicas, DefaultMinReplicas, scalingFactor)
+	if newReplicas == currentReplicas {
+		t.Log("Expected newReplicas > currentReplica")
+		t.Fail()
+	}
+}

--- a/gateway/handlers/alerthandler_test.go
+++ b/gateway/handlers/alerthandler_test.go
@@ -105,7 +105,7 @@ func TestScaledUpFrom1(t *testing.T) {
 	maxReplicas := uint64(5)
 	scalingFactor := uint64(30)
 	newReplicas := CalculateReplicas("firing", currentReplicas, maxReplicas, scaling.DefaultMinReplicas, scalingFactor)
-	if newReplicas == currentReplicas {
+	if newReplicas <= currentReplicas {
 		t.Log("Expected newReplicas > currentReplica")
 		t.Fail()
 	}
@@ -116,7 +116,7 @@ func TestScaledUpWithSmallParam(t *testing.T) {
 	maxReplicas := uint64(4)
 	scalingFactor := uint64(1)
 	newReplicas := CalculateReplicas("firing", currentReplicas, maxReplicas, scaling.DefaultMinReplicas, scalingFactor)
-	if newReplicas == currentReplicas {
+	if newReplicas <= currentReplicas {
 		t.Log("Expected newReplicas > currentReplica")
 		t.Fail()
 	}

--- a/gateway/handlers/alerthandler_test.go
+++ b/gateway/handlers/alerthandler_test.go
@@ -54,8 +54,8 @@ func TestInitialScale(t *testing.T) {
 	minReplicas := uint64(1)
 	scalingFactor := uint64(20)
 	newReplicas := CalculateReplicas("firing", scaling.DefaultMinReplicas, scaling.DefaultMaxReplicas, minReplicas, scalingFactor)
-	if newReplicas != 4 {
-		t.Log("Expected the increment to equal 4")
+	if newReplicas != 5 {
+		t.Log("Expected the increment to equal 5")
 		t.Fail()
 	}
 }
@@ -104,7 +104,7 @@ func TestScaledUpFrom1(t *testing.T) {
 	currentReplicas := uint64(1)
 	maxReplicas := uint64(5)
 	scalingFactor := uint64(30)
-	newReplicas := CalculateReplicas("firing", currentReplicas, maxReplicas, DefaultMinReplicas, scalingFactor)
+	newReplicas := CalculateReplicas("firing", currentReplicas, maxReplicas, scaling.DefaultMinReplicas, scalingFactor)
 	if newReplicas == currentReplicas {
 		t.Log("Expected newReplicas > currentReplica")
 		t.Fail()


### PR DESCRIPTION
Signed-off-by: Gede Wahyu <tokekbesi@gmail.com>

## Description
- Fix replica calculation to enable scaled up from 1 when max replica or scale factor is small

## Motivation and Context
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

When I have this config:
- current replica = 1
- max replica = 5
- scale factor = 30

it will never scaled up from 1. 

It will scaled up iff #MaxReplica * #ScaleFactor >= 200

## How Has This Been Tested?
I create new test case and already run test for `alerthandler_test.go`
Also tested on kubernetes using hey tool and figlet with max-replicas=5 and scale-factor=1
Result :
```
2018/12/01 18:02:13 [Scale] function=figlet 1 => 2.
2018/12/01 18:02:53 [Scale] function=figlet 2 => 3.
2018/12/01 18:03:33 [Scale] function=figlet 3 => 4.
2018/12/01 18:04:13 [Scale] function=figlet 4 => 5.
```
Result using default configuration, max-replicas=20 and scale-factor=20:
```
2018/12/01 18:21:28 [Scale] function=figlet 1 => 5.
2018/12/01 18:22:08 [Scale] function=figlet 5 => 9.
2018/12/01 18:22:48 [Scale] function=figlet 9 => 13.
2018/12/01 18:23:28 [Scale] function=figlet 13 => 17.
2018/12/01 18:24:08 [Scale] function=figlet 17 => 20.
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
