### PR TITLE
[WIP] - Feature/secret management to facilitate proposal #807

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ certifier
 .editorconfig
 /contrib/staging/
 **/*.sha256
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,78 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "generic/ubuntu1604"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "./", "/vagrant"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+    # Display the VirtualBox GUI when booting the machine
+    vb.gui = false
+  
+    # Customize the amount of memory on the VM:
+    vb.memory = "2048"
+  end
+
+  config.vm.provider "vmware_fusion" do |vmf|
+    vmf.gui = false
+    vmf.memory = "2048"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "docker"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    docker swarm init
+    cd /vagrant
+    sh deploy_stack.sh
+  SHELL
+end

--- a/api-docs/swagger.yml
+++ b/api-docs/swagger.yml
@@ -253,6 +253,87 @@ paths:
           description: Not Found
         '500':
           description: Internal Server Error
+  '/system/secrets':
+    get:
+      summary: 'Get a list of secret names and metadata from the provider'
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        '200':
+          description: List of submitted secrets.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/ListSecretsResponse'
+    post:
+      summary: Create a new secret.
+      description: ''
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - in: body
+        name: body
+        description: A new secret to create
+        required: true
+        schema:
+          $ref: '#/definitions/SecretInfo'
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad Request
+        '500':
+          description: Internal Server Error
+    put:
+      summary: Update a secret.
+      description: ''
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - in: body
+        name: body
+        description: Secret to update
+        required: true
+        schema:
+          $ref: '#/definitions/SecretInfo'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found
+        '500':
+          description: Internal Server Error
+    delete:
+      summary: Remove a secret.
+      description: ''
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - in: body
+        name: body
+        description: Secret to delete
+        required: true
+        schema:
+          $ref: '#/definitions/DeleteSecretRequest'
+      responses:
+        '204':
+          description: OK
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found
+        '500':
+          description: Internal Server Error
   '/system/info':
     get:
       summary: Get info such as provider version number and provider orchestrator

--- a/contrib/Vagrantfile
+++ b/contrib/Vagrantfile
@@ -23,16 +23,16 @@ Vagrant.configure("2") do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
   # NOTE: This will enable public access to the opened port
-  # config.vm.network "forwarded_port", guest: 80, host: 8080
+  # config.vm.network "forwarded_port", guest: 8080, host: 8080
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine and only allow access
   # via 127.0.0.1 to disable public access
-  config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
+  # config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network "private_network", ip: "192.168.50.2"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "./", "/vagrant"
+  config.vm.synced_folder "../", "/vagrant"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
@@ -71,7 +71,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "docker"
 
   config.vm.provision "shell", inline: <<-SHELL
-    docker swarm init
+    docker swarm init --advertise-addr 192.168.50.2
     cd /vagrant
     sh deploy_stack.sh
   SHELL

--- a/gateway/requests/requests.go
+++ b/gateway/requests/requests.go
@@ -91,9 +91,15 @@ type DeleteFunctionRequest struct {
 	FunctionName string `json:"functionName"`
 }
 
-// CreateSecretRequest create a secret w/ annotations
-type CreateSecretRequest struct {
-	Secret Secret `json:"secret"`
+// SecretInfo payload for PUT,POST secret w/ annotations
+type SecretInfo struct {
+	Secret      Secret            `json:"secret"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// ListSecretsResponse GET response for secrets (value omitted)
+type ListSecretsResponse struct {
+	Secrets []SecretInfo `json:"secrets"`
 }
 
 // DeleteSecretRequest remote a secret by name
@@ -101,9 +107,8 @@ type DeleteSecretRequest struct {
 	SecretName string `json:"secretName"`
 }
 
-// Secret schema use Value only in write-only http verbs
+// Secret schema use Value only in PUT,POST http verbs
 type Secret struct {
-	Name        string             `json:"name"`
-	Value       string             `json:"value"` // write-only
-	Annotations *map[string]string `json:"annotations"`
+	Name  string `json:"name"`
+	Value string `json:"value,omitempty"` // write-only, base64
 }

--- a/gateway/requests/requests.go
+++ b/gateway/requests/requests.go
@@ -90,3 +90,8 @@ type AsyncReport struct {
 type DeleteFunctionRequest struct {
 	FunctionName string `json:"functionName"`
 }
+
+// SecretRequest create, update a secret
+type SecretRequest struct {
+	Secrets *map[string]string `json:"secrets"`
+}

--- a/gateway/requests/requests.go
+++ b/gateway/requests/requests.go
@@ -91,7 +91,19 @@ type DeleteFunctionRequest struct {
 	FunctionName string `json:"functionName"`
 }
 
-// SecretRequest create, update a secret
-type SecretRequest struct {
-	Secrets *map[string]string `json:"secrets"`
+// CreateSecretRequest create a secret w/ annotations
+type CreateSecretRequest struct {
+	Secret Secret `json:"secret"`
+}
+
+// DeleteSecretRequest remote a secret by name
+type DeleteSecretRequest struct {
+	SecretName string `json:"secretName"`
+}
+
+// Secret schema use Value only in write-only http verbs
+type Secret struct {
+	Name        string             `json:"name"`
+	Value       string             `json:"value"` // write-only
+	Annotations *map[string]string `json:"annotations"`
 }

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -163,7 +163,7 @@ func main() {
 	r.HandleFunc("/system/functions", faasHandlers.UpdateFunction).Methods(http.MethodPut)
 	r.HandleFunc("/system/scale-function/{name:[-a-zA-Z_0-9]+}", faasHandlers.ScaleFunction).Methods(http.MethodPost)
 
-	r.HandleFunc("/system/secrets", faasHandlers.SecretHandler).Methods(http.MethodGet, http.MethodPut, http.MethodPost)
+	r.HandleFunc("/system/secrets", faasHandlers.SecretHandler).Methods(http.MethodGet, http.MethodPut, http.MethodPost, http.MethodDelete)
 
 	if faasHandlers.QueuedProxy != nil {
 		r.HandleFunc("/async-function/{name:[-a-zA-Z_0-9]+}/", faasHandlers.QueuedProxy).Methods(http.MethodPost)

--- a/gateway/types/handler_set.go
+++ b/gateway/types/handler_set.go
@@ -26,4 +26,7 @@ type HandlerSet struct {
 
 	// InfoHandler provides version and build info
 	InfoHandler http.HandlerFunc
+
+	// SecretHandler allows secrets to be managed
+	SecretHandler http.HandlerFunc
 }


### PR DESCRIPTION
## Description
This is the first round of changes to facilitate a simpler way of managing secrets by adding a new route and secret handler to be implemented in each respective provider.

## Motivation and Context
From proposal #807 
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Not fully tested yet, only manual integration tests done in Vagrant/Docker Swarm environment. TODO: add integration tests in pre-defined location

AFAICT: This feature introduces a new handler for the providers to implement CLUD on secrets: faas-netes,swarm,nomad, faas-provider? faas-cli functionality also needs to be implemented (another PR outside of this scope)
## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
