### PR TITLE
Config metrics endpoint

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -71,6 +71,7 @@ The gateway can be configured through the following environment variables:
 | `faas_nats_port`    | Port for NATS service. Requrired for asynchronous mode |
 | `faas_prometheus_host`         | Host to connect to Prometheus. Default: `"prometheus"` |
 | `faas_promethus_port`         | Port to connect to Prometheus. Default: `9090` |
+| `metrics_endpoint`            | Gateway metrics endpoint scraped by Prometheus. Default: `/metrics` |
 | `direct_functions`            | `true` or `false` -  functions are invoked directly over overlay network by DNS name without passing through the provider |
 | `direct_functions_suffix`     | Provide a DNS suffix for invoking functions directly over overlay network  |
 | `basic_auth`              | Set to `true` or `false` to enable embedded basic auth on the /system and /ui endpoints (recommended) |

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -182,7 +182,7 @@ func main() {
 	}
 
 	metricsHandler := metrics.PrometheusHandler()
-	r.Handle("/metrics", metricsHandler)
+	r.Handle(config.MetricsEndpoint, metricsHandler)
 	r.HandleFunc("/healthz", handlers.MakeForwardingProxyHandler(reverseProxy, forwardingNotifiers, urlResolver, nilURLTransformer)).Methods(http.MethodGet)
 
 	r.Handle("/", http.RedirectHandler("/ui/", http.StatusMovedPermanently)).Methods(http.MethodGet)

--- a/gateway/types/readconfig.go
+++ b/gateway/types/readconfig.go
@@ -102,6 +102,12 @@ func (ReadConfig) Read(hasEnv HasEnv) GatewayConfig {
 		cfg.PrometheusHost = prometheusHost
 	}
 
+	metricsEndpoint := hasEnv.Getenv("metrics_endpoint")
+	if len(metricsEndpoint) == 0 {
+		metricsEndpoint = "/metrics"
+	}
+	cfg.MetricsEndpoint = metricsEndpoint
+
 	cfg.DirectFunctions = parseBoolValue(hasEnv.Getenv("direct_functions"))
 	cfg.DirectFunctionsSuffix = hasEnv.Getenv("direct_functions_suffix")
 
@@ -143,6 +149,9 @@ type GatewayConfig struct {
 
 	// Port to connect to Prometheus.
 	PrometheusPort int
+
+	// Metrics endpoint that is going to be scraped by Prometheus
+	MetricsEndpoint string
 
 	// If set to true we will access upstream functions directly rather than through the upstream provider
 	DirectFunctions bool

--- a/gateway/types/readconfig_test.go
+++ b/gateway/types/readconfig_test.go
@@ -221,6 +221,32 @@ func TestRead_PrometheusDefaults(t *testing.T) {
 	}
 }
 
+func TestRead_MetricsEndpointNonDefaults(t *testing.T) {
+	defaults := NewEnvBucket()
+	defaults.Setenv("metrics_endpoint", "/server/metrics")
+	readConfig := ReadConfig{}
+
+	config := readConfig.Read(defaults)
+
+	if config.MetricsEndpoint != "/server/metrics" {
+		t.Logf("config.MetricsEndpoint, want: %s, got: %s\n", "/server/metrics", config.MetricsEndpoint)
+		t.Fail()
+	}
+}
+
+func TestRead_MetricsEndpointDefaults(t *testing.T) {
+	defaults := NewEnvBucket()
+
+	readConfig := ReadConfig{}
+
+	config := readConfig.Read(defaults)
+
+	if config.MetricsEndpoint != "/metrics" {
+		t.Logf("config.MetricsEndpoint, want: %s, got: %s\n", "/metrics", config.MetricsEndpoint)
+		t.Fail()
+	}
+}
+
 func TestRead_BasicAuthDefaults(t *testing.T) {
 	defaults := NewEnvBucket()
 


### PR DESCRIPTION
Make metrics endpoint configurable via 'metrics_endpoint'
environment variable. Default is '/metrics'.

Signed-off-by: Khalid Hasanov <xalid.h@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
This change is a new feature making it possible to override gateway metrics
endpoint.  

## Description
<!--- Describe your changes in detail -->
This change is a new feature making it possible to override gateway metrics
endpoint. By using metrics_endpoint environment variable users can override
gateway metrics endpoints. The default value is '/metrics' which is the same as before.
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Not all Prometheus setups are configured to scrape '/metrics' endpoint and
therefore, this change would make it easier to have a consistent Prometheus 
config for different systems.

<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
https://github.com/openfaas/faas/issues/998

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
The change has been used with OpenFaaS Nomad plugin.
<!--- Include details of your testing environment, and the tests you ran to -->
The tests were run by overriding 'metrics_endpoint' environment variable and 
making sure Prometheus can scrape the metrics.
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
