### PR TITLE
Fix fwatchdog timer memory leak issue

### DIFF
--- a/watchdog/handler.go
+++ b/watchdog/handler.go
@@ -109,10 +109,7 @@ func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request,
 	var timer *time.Timer
 
 	if config.execTimeout > 0*time.Second {
-		timer = time.NewTimer(config.execTimeout)
-
-		go func() {
-			<-timer.C
+		timer = time.AfterFunc(config.execTimeout, func() {
 			log.Printf("Killing process: %s\n", config.faasProcess)
 			if targetCmd != nil && targetCmd.Process != nil {
 				ri.headerWritten = true
@@ -125,7 +122,7 @@ func pipeRequest(config *WatchdogConfig, w http.ResponseWriter, r *http.Request,
 					log.Printf("Killed process: %s - error %s\n", config.faasProcess, val.Error())
 				}
 			}
-		}()
+		})
 	}
 
 	// Write to pipe in separate go-routine to prevent blocking


### PR DESCRIPTION
Use timer.AfterFunc to make sure goroutine could be gc.

Signed-off-by: Mike Chiu <mike.chiu@pentium.network>

<!--- Provide a general summary of your changes in the Title above -->
Fix fwatchdog leak after stress testing or heavy loading.

## Description
<!--- Describe your changes in detail -->
Use time.AfterFunc to replace timer.NewTimer to avoid leak.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([#1000](https://github.com/openfaas/faas/issues/1000))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. use build.sh to build fwatchdog image
2. run docker: ```docker run -it --entrypoint=sh --name=watchdog -p 8080:8080 {image}```
3. set env. variable: ```export fprocess="cat /etc/hostname"```
4. execute fwatchdog http server: ```fwatchdog```
5. outside the container, monitor stats of container: ```docker stats watchdog``` 
6. use ab to do stress testing: ```ab -n 1000 -c 100 https://localhost:8080```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
