### PR TITLE
Add build-args to Dockerfile.armhf

### DIFF
--- a/gateway/Dockerfile.armhf
+++ b/gateway/Dockerfile.armhf
@@ -1,4 +1,11 @@
 FROM golang:1.10.4 as build
+ARG GIT_COMMIT_SHA
+ARG GIT_COMMIT_MESSAGE
+ARG VERSION='dev'
+
+RUN curl -sSfL https://github.com/alexellis/license-check/releases/download/0.2.3/license-check-armhf \
+    > /usr/bin/license-check \
+    && chmod +x /usr/bin/license-check
 
 WORKDIR /go/src/github.com/openfaas/faas/gateway
 
@@ -16,17 +23,39 @@ COPY version        version
 COPY scaling        scaling
 COPY server.go      .
 
-RUN GOARM=7 CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o gateway .
+# Run a gofmt and exclude all vendored code.
+RUN license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Project" "OpenFaaS Authors" "OpenFaaS Author(s)" \
+    && test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))" \
+    && go test $(go list ./... | grep -v integration | grep -v /vendor/ | grep -v /template/) -cover \
+    && GOARM=7 CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w \
+    -X github.com/openfaas/faas/gateway/version.GitCommitSHA=${GIT_COMMIT_SHA}\
+    -X \"github.com/openfaas/faas/gateway/version.GitCommitMessage=${GIT_COMMIT_MESSAGE}\"\
+    -X github.com/openfaas/faas/gateway/version.Version=${VERSION}" \
+    -a -installsuffix cgo -o gateway .
 
 FROM alpine:3.8
-WORKDIR /root/
+
+LABEL org.label-schema.license="MIT" \
+    org.label-schema.vcs-url="https://github.com/openfaas/faas" \
+    org.label-schema.vcs-type="Git" \
+    org.label-schema.name="openfaas/faas" \
+    org.label-schema.vendor="openfaas" \
+    org.label-schema.docker.schema-version="1.0"
+
+RUN addgroup -S app \
+    && adduser -S -g app app
+
+WORKDIR /home/app
 
 EXPOSE 8080
 ENV http_proxy      ""
 ENV https_proxy     ""
 
-COPY --from=0 /go/src/github.com/openfaas/faas/gateway/gateway    .
+COPY --from=build /go/src/github.com/openfaas/faas/gateway/gateway    .
 
 COPY assets     assets
-RUN sed -ie s/store.json/store-armhf.json/g /root/assets/script/funcstore.js
+RUN sed -ie s/store.json/store-armhf.json/g /home/app/assets/script/funcstore.js
+RUN chown -R app:app ./
+USER app
+
 CMD ["./gateway"]


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description

This change carries the changes made to `Dockerfile` when /system/info was introduces through to `Dockerfile.armhf`.  As well as the build-args which fix the identified issue the license check has also been added at the latest release 0.2.3, as a armhf build has been made available.  Further changes are to introduce the app user and moving the binary location from /root/ to /home/app/

## Motivation and Context
Fixes #1040 
When the /system/info endpoint was expanded to include information about the gateway a number of build-args were added to the main Dockerfile.  These changes were not mirrored in Dockerfile.armhf, which resulted in nil attributes and an ugly error when running `faas version` against an armhf gateway.

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

Built on a Pi3:

```
$ ./build.sh

Building openfaas/gateway:latest-armhf-dev
Sending build context to Docker daemon  22.86MB
Step 1/31 : FROM golang:1.10.4 as build
 ---> 4c25e1a817d4
Step 2/31 : ARG GIT_COMMIT_SHA
 ---> Running in ac4dc3327375
Removing intermediate container ac4dc3327375
 ---> 3b20034446de
Step 3/31 : ARG GIT_COMMIT_MESSAGE
 ---> Running in b72c46e496ef
Removing intermediate container b72c46e496ef
 ---> 224a9a821d7c
Step 4/31 : ARG VERSION='dev'
 ---> Running in 5f3c39d60ef4
Removing intermediate container 5f3c39d60ef4
 ---> 58f8a75b0a84
Step 5/31 : RUN curl -sSfL https://github.com/alexellis/license-check/releases/download/0.2.3/license-check-armhf     > /usr/bin/license-check     && chmod +x /usr/bin/license-check
 ---> Running in afb968601790
Removing intermediate container afb968601790
 ---> e0dc20b5fa8f
Step 6/31 : WORKDIR /go/src/github.com/openfaas/faas/gateway
 ---> Running in eda2cd2ef4a6
Removing intermediate container eda2cd2ef4a6
 ---> 0dfc78cc6394
Step 7/31 : COPY vendor         vendor
 ---> cfb4509b7a41
Step 8/31 : COPY handlers       handlers
 ---> 81a3979a837f
Step 9/31 : COPY metrics        metrics
 ---> 6f6a8c11be2e
Step 10/31 : COPY requests       requests
 ---> f134d4a06d6b
Step 11/31 : COPY tests          tests
 ---> 4d0b221a6a04
Step 12/31 : COPY types          types
 ---> bc72c724fcf1
Step 13/31 : COPY queue          queue
 ---> a85eb113b700
Step 14/31 : COPY plugin         plugin
 ---> b2031cd840b6
Step 15/31 : COPY version        version
 ---> ce6a64de008c
Step 16/31 : COPY scaling        scaling
 ---> 2055cbcda35c
Step 17/31 : COPY server.go      .
 ---> fb82bd628b95
Step 18/31 : RUN license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Project" "OpenFaaS Authors" "OpenFaaS Author(s)"     && test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"     && go test $(go list ./... | grep -v integration | grep -v /vendor/ | grep -v /template/) -cover     && GOARM=7 CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w     -X github.com/openfaas/faas/gateway/version.GitCommitSHA=${GIT_COMMIT_SHA}    -X \"github.com/openfaas/faas/gateway/version.GitCommitMessage=${GIT_COMMIT_MESSAGE}\"    -X github.com/openfaas/faas/gateway/version.Version=${VERSION}"     -a -installsuffix cgo -o gateway .
 ---> Running in 8e2c4b6207b9
?   	github.com/openfaas/faas/gateway	[no test files]
ok  	github.com/openfaas/faas/gateway/handlers	0.041s	coverage: 24.1% of statements
ok  	github.com/openfaas/faas/gateway/metrics	0.038s	coverage: 40.9% of statements
ok  	github.com/openfaas/faas/gateway/plugin	0.102s	coverage: 81.4% of statements
?   	github.com/openfaas/faas/gateway/queue	[no test files]
ok  	github.com/openfaas/faas/gateway/requests	0.105s	coverage: 75.0% of statements
ok  	github.com/openfaas/faas/gateway/scaling	0.043s	coverage: 24.6% of statements
ok  	github.com/openfaas/faas/gateway/types	0.033s	coverage: 81.8% of statements
?   	github.com/openfaas/faas/gateway/version	[no test files]
Removing intermediate container 8e2c4b6207b9
 ---> 96f968003a9b
Step 19/31 : FROM alpine:3.8
 ---> d2696274f894
Step 20/31 : LABEL org.label-schema.license="MIT"     org.label-schema.vcs-url="https://github.com/openfaas/faas"     org.label-schema.vcs-type="Git"     org.label-schema.name="openfaas/faas"     org.label-schema.vendor="openfaas"     org.label-schema.docker.schema-version="1.0"
 ---> Running in 6946e79b7fe4
Removing intermediate container 6946e79b7fe4
 ---> fb037a3174d9
Step 21/31 : RUN addgroup -S app     && adduser -S -g app app
 ---> Running in 3d9704815d9e
Removing intermediate container 3d9704815d9e
 ---> 5769403b7684
Step 22/31 : WORKDIR /home/app
 ---> Running in ae1b67b3e324
Removing intermediate container ae1b67b3e324
 ---> 843e84abded0
Step 23/31 : EXPOSE 8080
 ---> Running in c76df2249550
Removing intermediate container c76df2249550
 ---> c00a15899158
Step 24/31 : ENV http_proxy      ""
 ---> Running in d2123275480f
Removing intermediate container d2123275480f
 ---> 9fa80a2385fa
Step 25/31 : ENV https_proxy     ""
 ---> Running in 4dee62e55ebf
Removing intermediate container 4dee62e55ebf
 ---> 59fa1ac73ec1
Step 26/31 : COPY --from=build /go/src/github.com/openfaas/faas/gateway/gateway    .
 ---> 97140a9873fe
Step 27/31 : COPY assets     assets
 ---> c219f7f90e9b
Step 28/31 : RUN sed -ie s/store.json/store-armhf.json/g /home/app/assets/script/funcstore.js
 ---> Running in 34660151dc03
Removing intermediate container 34660151dc03
 ---> d1602f5fe7f2
Step 29/31 : RUN chown -R app:app ./
 ---> Running in cba0fac63c2f
Removing intermediate container cba0fac63c2f
 ---> 56b33a2cdc2b
Step 30/31 : USER app
 ---> Running in 6fcec5c9664a
Removing intermediate container 6fcec5c9664a
 ---> ab63b3d0cd31
Step 31/31 : CMD ["./gateway"]
 ---> Running in faf59c4962f8
Removing intermediate container faf59c4962f8
 ---> 9484c96d82f5
Successfully built 9484c96d82f5
Successfully tagged openfaas/gateway:latest-armhf-dev
```
Deployed:
```
$ docker service update --image=openfaas/gateway:latest-armhf-dev func_gateway
image openfaas/gateway:latest-armhf-dev could not be accessed on a registry to record
its digest. Each node will access openfaas/gateway:latest-armhf-dev independently,
possibly leading to different nodes running different
versions of the image.

func_gateway
overall progress: 1 out of 1 tasks 
1/1: running   [==================================================>] 
verify: Service converged 
```

Checked the running container was the new one
```
$ docker ps
CONTAINER ID        IMAGE                                 COMMAND                  CREATED             STATUS                    PORTS                NAMES
51655c378f8e        openfaas/gateway:latest-armhf-dev     "./gateway"              2 minutes ago      Up 18 minutes             8080/tcp             func_gateway.1.p0bekbw0xg246hy6cmo0l3gh8
30cbae7aef20        openfaas/queue-worker:0.5.3-armhf     "./app"                  2 hours ago         Up 2 hours                8080/tcp             func_queue-worker.1.tqmmvt1pcynr95pxrgpvp50kn
ce4e3f92de03        nats-streaming:0.11.2                 "/nats-streaming-ser…"   2 hours ago         Up 2 hours                4222/tcp, 8222/tcp   func_nats.1.ozee3p9ew436o2j74sbrwwebx
0db9a7098d22        openfaas/faas-swarm:0.5.0-armhf       "./faas-swarm"           2 hours ago         Up 2 hours                8080/tcp             func_faas-swarm.1.rl5h7gupqt6678hlsvj2sfrgv
af78d0750d94        alexellis2/prometheus:2.0-armhf       "/bin/prometheus --c…"   3 hours ago         Up 2 hours                9090/tcp             func_prometheus.1.139rbfnmlzrasqije4hnh3dv8
9916efbbef28        alexellis2/alertmanager-armhf:0.5.1   "/bin/alertmanager -…"   3 hours ago         Up 2 hours                9093/tcp             func_alertmanager.1.yxea5r2wn398dr7otkb7am5hg
```

Output from `docker service ls`
```
ID                  NAME                MODE                REPLICAS            IMAGE                                 PORTS
us52lnsuu4vr        func_alertmanager   replicated          1/1                 alexellis2/alertmanager-armhf:0.5.1   
phdothuz6c2m        func_faas-swarm     replicated          1/1                 openfaas/faas-swarm:0.5.0-armhf       
jcy7hxbjdw90        func_gateway        replicated          1/1                 openfaas/gateway:latest-armhf-dev     *:8080->8080/tcp
cmm79gtm3eam        func_nats           replicated          1/1                 nats-streaming:0.11.2                 
2qs6dh79cakr        func_prometheus     replicated          1/1                 alexellis2/prometheus:2.0-armhf       *:9090->9090/tcp
q524scdyspid        func_queue-worker   replicated          1/1                 openfaas/queue-worker:0.5.3-armhf     
```

Accessed the previously erroneous endpoint and confirmed the output:

```
{"provider":{"provider":"faas-swarm","version":{"sha":"4269ab15673ad883bfdce4df47c055588e8e86b2","release":"0.5.0"},"orchestration":"swarm"},"version":{"commit_message":"Add article from ineat-conseil","sha":"d17a42ce15e57e91f35320f427bf429603b9d192","release":"dev"}}
```

Deployed and executed a function from the store:

```
$ docker service ls
ID                  NAME                MODE                REPLICAS            IMAGE                                 PORTS                  
s36kqjy2utym        figlet              replicated          1/1                 functions/figlet:latest-armhf 

$  echo 'Testing' | faas invoke figlet
 _____         _   _             
|_   _|__  ___| |_(_)_ __   __ _ 
  | |/ _ \/ __| __| | '_ \ / _` |
  | |  __/\__ \ |_| | | | | (_| |
  |_|\___||___/\__|_|_| |_|\__, |
                           |___/ 
```

Ran `faas version`:

```
$ faas version
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  a141dedf94ffeed84412365fd591bdc8999c5a1b
 version: 0.8.3

Gateway
 uri:     http://127.0.0.1:8080
 version: dev
 sha:     d17a42ce15e57e91f35320f427bf429603b9d192
 commit:  Add article from ineat-conseil


Provider
 name:          faas-swarm
 orchestration: swarm
 version:       0.5.0 
 sha:           4269ab15673ad883bfdce4df47c055588e8e86b2
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
