### PR TITLE
Add basic auth to the system alert endpoint

### DIFF
--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -5,7 +5,7 @@ services:
             - "/var/run/docker.sock:/var/run/docker.sock"
         ports:
             - 8080:8080
-        image: functions/gateway:0.10.0-arm64
+        image: functions/gateway:0.7.0-arm64
         networks:
             - functions
         environment:

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -5,7 +5,7 @@ services:
             - "/var/run/docker.sock:/var/run/docker.sock"
         ports:
             - 8080:8080
-        image: functions/gateway:0.7.0-arm64
+        image: functions/gateway:0.10.0-arm64
         networks:
             - functions
         environment:

--- a/docker-compose.armhf.yml
+++ b/docker-compose.armhf.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.10.0-armhf
+        image: openfaas/gateway:0.9.14-armhf
         networks:
             - functions
         environment:

--- a/docker-compose.armhf.yml
+++ b/docker-compose.armhf.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.9.14-armhf
+        image: openfaas/gateway:0.10.0-armhf
         networks:
             - functions
         environment:
@@ -169,7 +169,8 @@ services:
         configs:
             - source: alertmanager_config
               target: /alertmanager.yml
-
+        secrets:
+            - basic-auth-password
 
 configs:
      prometheus_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.10.0
+        image: openfaas/gateway:0.9.14
         networks:
             - functions
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.9.14
+        image: openfaas/gateway:0.10.0
         networks:
             - functions
         environment:
@@ -173,6 +173,8 @@ services:
         configs:
             - source: alertmanager_config
               target: /alertmanager.yml
+        secrets:
+            - basic-auth-password
 
 
 configs:

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -112,6 +112,8 @@ func main() {
 	faasHandlers.ScaleFunction = handlers.MakeForwardingProxyHandler(reverseProxy, forwardingNotifiers, urlResolver, nilURLTransformer)
 
 	if credentials != nil {
+		faasHandlers.Alert =
+			auth.DecorateWithBasicAuth(faasHandlers.Alert, credentials)
 		faasHandlers.UpdateFunction =
 			auth.DecorateWithBasicAuth(faasHandlers.UpdateFunction, credentials)
 		faasHandlers.DeleteFunction =

--- a/prometheus/alertmanager.yml
+++ b/prometheus/alertmanager.yml
@@ -20,3 +20,7 @@ receivers:
   webhook_configs:
     - url: http://gateway:8080/system/alert
       send_resolved: true
+      http_config:
+            basic_auth:
+              username: admin
+              password_file: /run/secrets/basic-auth-password


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Protect the `/system/alert` endpoint when basic auth is enabled
- Update the alert manager config to send the basic auth credentials
- Bump the gateway version


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

This issue was raised by @alexellis on slack

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually in docker swarm and in k8s.

Create `spammer.sh`
```sh
#! /bin/bash
gateway=localhost:31112
fnc=cows
sleepSec=0
while true; do
    echo "" | faas-cli invoke "$fnc" --gateway "$gateway"
    sleep $sleepSec
done
```

In swarm (I have pushed a pre-built image to theaxer/gateway:0.10.0)
```sh
make build-gateway
docker tag openfaas/gateway:latest-dev openfaas/gateway:0.10.0
#  modify docker-compose.yml gateway image to be openfaas/gateway:latest-dev
echo "testpass" | docker secret create basic-auth-password -
./deploy_stack.sh


export gateway=localhost:8080

# test that the credentials are required for the alert endpoint
curl -X POST http://$gateway/system/alert -d '{}'
# invalid credentials%

# test that scaling still works by spamming a function
faas-cli -g $gateway login -u admin --password testpass
faas-cli -g $gateway store deploy cows

# in a new shell, run the spammer
./spammer.sh

# watch the gateway logs for `Alert received.` message
docker service logs func_gateway -f
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This gateway image will break deployments that have basic auth enabled but have not updated the alert manager configuration. They will need to redeploy openfaas (or manually update their alert manager).  I am not sure how we want to document/announce this.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
