### PR TITLE
Fix publish-arm.sh using wrong image name for report

### DIFF
--- a/contrib/publish-arm.sh
+++ b/contrib/publish-arm.sh
@@ -62,5 +62,6 @@ do
    cd ./staging/$i
    export TAG=$(git describe --abbrev=0 --tags)
    echo "$i"
+   REPOSITORY=$(get_repo_name $i)
    echo " ${REPOSITORY}:${TAG}-${ARM_VERSION}"
 done


### PR DESCRIPTION
Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Started it on ARMHF - 
```bash
Successfully built ad68a4ff33a7
Successfully tagged openfaas/queue-worker:0.6.0-armhf
Docker images
openfaas/faas
 openfaas/gateway:0.10.2-armhf
openfaas/nats-queue-worker
 openfaas/queue-worker:0.6.0-armhf
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.