### PR TITLE
http signatures: add support for RSA message signing

### DIFF
--- a/deploy_stack.sh
+++ b/deploy_stack.sh
@@ -51,6 +51,20 @@ else
   echo ""
 fi
 
+# Setup http signatures keys
+rm signing.key > /dev/null 2>&1 || true && rm signing.key.pub > /dev/null 2>&1 || true
+docker secret rm http-signing-private-key > /dev/null 2>&1 || true
+docker secret rm http-signing-public-key > /dev/null 2>&1 || true
+
+ssh-keygen -t rsa -b 2048 -N "" -m PEM -f signing.key > /dev/null 2>&1
+openssl rsa -in ./signing.key -pubout -outform PEM -out signing.key.pub > /dev/null 2>&1
+
+cat signing.key | docker secret create http-signing-private-key - > /dev/null 2>&1 || true
+cat signing.key.pub | docker secret create http-signing-public-key - > /dev/null 2>&1 || true
+
+rm signing.key || true && rm signing.key.pub || true
+echo "Http encryption settings enabled..\n"
+
 arch=$(uname -m)
 case "$arch" in
 

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -40,6 +40,7 @@ services:
         secrets:
             - basic-auth-user
             - basic-auth-password
+            - http-signing-public-key
 
     # auth service provide basic-auth plugin for system APIs
     basic-auth-plugin:
@@ -150,6 +151,7 @@ services:
         secrets:
             - basic-auth-user
             - basic-auth-password
+            - http-signing-private-key
 
     # End services
 
@@ -231,4 +233,8 @@ secrets:
     basic-auth-user:
         external: true
     basic-auth-password:
+        external: true
+    http-signing-public-key:
+        external: true
+    http-signing-private-key:
         external: true

--- a/docker-compose.armhf.yml
+++ b/docker-compose.armhf.yml
@@ -68,6 +68,7 @@ services:
         secrets:
             - basic-auth-user
             - basic-auth-password
+            - http-signing-public-key
 
     # Docker Swarm provider
     faas-swarm:
@@ -149,6 +150,7 @@ services:
         secrets:
             - basic-auth-user
             - basic-auth-password
+            - http-signing-private-key
 
     # End services
 
@@ -230,4 +232,8 @@ secrets:
     basic-auth-user:
         external: true
     basic-auth-password:
+        external: true
+    http-signing-public-key:
+        external: true
+    http-signing-private-key:
         external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
         secrets:
             - basic-auth-user
             - basic-auth-password
+            - http-signing-public-key
 
     # auth service provide basic-auth plugin for system APIs
     basic-auth-plugin:
@@ -149,6 +150,7 @@ services:
         secrets:
             - basic-auth-user
             - basic-auth-password
+            - http-signing-private-key
 
     # End services
 
@@ -229,4 +231,8 @@ secrets:
     basic-auth-user:
         external: true
     basic-auth-password:
+        external: true
+    http-signing-public-key:
+        external: true
+    http-signing-private-key:
         external: true

--- a/gateway/handlers/certificates_handler.go
+++ b/gateway/handlers/certificates_handler.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path"
+
+	"github.com/gorilla/mux"
+)
+
+var keyMap = map[string]string{
+	"callback": "http-signing-public-key",
+}
+
+type KeyType struct {
+	Id  string `json:"id"`
+	PEM string `json:"pem"`
+}
+
+type SecretsReader interface {
+	Read(key string) (string, error)
+}
+
+type FileSecretsReader struct {
+	SecretMountPath string
+}
+
+func (f *FileSecretsReader) Read(key string) (string, error) {
+	if len(f.SecretMountPath) == 0 {
+		return "", fmt.Errorf("invalid SecretMountPath specified for reading secrets used for certificates")
+	}
+
+	certificatePath := path.Join(f.SecretMountPath, key)
+	if _, err := os.Stat(certificatePath); os.IsNotExist(err) {
+		return "", fmt.Errorf("unable to find secret %s", key)
+	}
+
+	value, err := ioutil.ReadFile(certificatePath)
+	if err != nil {
+		return "", fmt.Errorf("error reading find secret %s", certificatePath)
+	}
+
+	return string(value), nil
+}
+
+func MakeCertificatesHandler(reader SecretsReader) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		keyID := vars["id"]
+		secretKey, ok := keyMap[keyID]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			message := fmt.Sprintf("Unable to find certificate %s.", keyID)
+			w.Write([]byte(message))
+			log.Println(message)
+			return
+		}
+
+		publicKey, err := reader.Read(secretKey)
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			message := fmt.Sprintf("Unable to find secret for key %s.", keyID)
+			w.Write([]byte(message))
+			log.Println(message)
+			return
+		}
+
+		key := &KeyType{
+			Id:  secretKey,
+			PEM: publicKey,
+		}
+
+		bytesOut, marshalErr := json.Marshal(key)
+		if marshalErr != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			message := fmt.Sprintf("error marshalling json for key %s. %v", keyID, err)
+			w.Write([]byte(message))
+			log.Println(message)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(bytesOut)
+	}
+}

--- a/gateway/handlers/certificates_handler_test.go
+++ b/gateway/handlers/certificates_handler_test.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestMakeCertificatesHandler(t *testing.T) {
+	tests := []struct {
+		name   string
+		keyID  string
+		eval   func(r *http.Response) error
+		reader SecretsReader
+	}{
+		{
+			name:  "Get certificate that exists",
+			keyID: "callback",
+			eval: func(r *http.Response) error {
+				if r.StatusCode != 200 {
+					return fmt.Errorf("expected 200")
+				}
+
+				body, _ := ioutil.ReadAll(r.Body)
+				keyData := &KeyType{}
+				if err := json.Unmarshal(body, keyData); err != nil {
+					return fmt.Errorf("error unmarshalling result")
+				}
+
+				if keyData.PEM != testPublicKey {
+					return fmt.Errorf("PEM want %s got %s", testPublicKey, keyData.PEM)
+				}
+				return nil
+			},
+			reader: &TestSecretsReader{readCallBack: func(key string) (s string, e error) {
+				return testPublicKey, nil
+			}},
+		},
+		{
+
+			name:  "Attempt to get certificate that doesn't exist",
+			keyID: "missingID",
+			eval: func(r *http.Response) error {
+				if r.StatusCode != 404 {
+					return fmt.Errorf("expected 404")
+				}
+
+				return nil
+			},
+			reader: &TestSecretsReader{readCallBack: func(key string) (s string, e error) {
+				return "", fmt.Errorf("key not found")
+			}},
+		},
+	}
+
+	r := mux.NewRouter()
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r.HandleFunc("/certificates/{id}", MakeCertificatesHandler(tt.reader))
+
+			url := ts.URL + "/certificates/" + tt.keyID
+			resp, err := http.Get(url)
+			if err != nil {
+				t.Errorf("MakeCertificatesHandler() call = %v", err)
+			}
+
+			if err := tt.eval(resp); err != nil {
+				t.Errorf("MakeCertificatesHandler() eval = %v", err)
+			}
+		})
+	}
+}
+
+type TestSecretsReader struct {
+	readCallBack func(key string) (string, error)
+}
+
+func (r *TestSecretsReader) Read(key string) (string, error) {
+	return r.readCallBack(key)
+}
+
+const testPublicKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7pEUKQ28pI5N3g/zG6OJ
+100N/DV2Q8Ob+gzRjd7HjXgVgZyjS3nA8FAYrxTLSihcIhXuQrYxyk2vp6YMNmSB
+fOptkdmj4UgLYskfeqEt8JjS6ExBxSWEDgr1IXOPPDP61on8F65/ZYGnp2JF2wHY
+k0OeD4ppNUV+mIHj/wXf7VLHGflwFQH/+mfUn+tVQRgX7hTadcYmGJ+1XP0py4kU
+gJDHfw8eBsFurHWr2mXu3BdraSKKf1G9i+SifmOUUul6mBONmlvzQdKtDCr48o1H
+QndRHcMWjKhlBhKz4qrmqku8oGBh6iHhGVVYf8D3mU1nzyjH4rOUXZwzj+SaqgGk
+vQIDAQAB
+-----END PUBLIC KEY-----`

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -248,7 +248,7 @@ func main() {
 
 	r.HandleFunc("/healthz",
 		handlers.MakeForwardingProxyHandler(reverseProxy, forwardingNotifiers, urlResolver, nilURLTransformer, serviceAuthInjector)).Methods(http.MethodGet)
-
+	r.Handle("/certificates/{id}", handlers.MakeCertificatesHandler(&handlers.FileSecretsReader{SecretMountPath: config.SecretMountPath}))
 	r.Handle("/", http.RedirectHandler("/ui/", http.StatusMovedPermanently)).Methods(http.MethodGet)
 
 	tcpPort := 8080


### PR DESCRIPTION
TODO:

- [x] mac osx testing
- [x] linux testing
- [ ] arm

## Description
Updates deployment script to create keys for http-signatures

## Motivation and Context
Resolves issue #1103

## How Has This Been Tested?
- [x] **Mac (mojave)**

Output running on a system not running OpenFaaS:
```
$ ./deploy_stack.sh                                                                                                                          
Attempting to create credentials for gateway..
5kt9oxodp7xyz5td0lkxlzrin
yvrtnodgstfkukaeyga4vs4tr
[Credentials]
 username: admin 
 password: b676451f42836f2d39d7012d51714c64bde4630c6b022708285e39f776608c68
 echo -n b676451f42836f2d39d7012d51714c64bde4630c6b022708285e39f776608c68 | faas-cli login --username=admin --password-stdin

Enabling basic authentication for gateway..

Http encryption settings enabled

Deploying OpenFaaS core services
Creating service func_nats
Creating service func_queue-worker
Creating service func_prometheus
Creating service func_alertmanager
Creating service func_gateway
Creating service func_faas-swarm

```

**Requesting a known public key**

```
$ curl localhost:8080/certificates/callback -s | jq '.pem' -r                                                                   

-----BEGIN PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3tjZ3yP8DzZTKSVDuNKV
HZJWqhdVWlwuqFdOwJ+ArL65BLEH+aVO+jXjI2IoQDrGgg5dw1zdCiGundL/SMLa
4ABz2wAIbEEafvPMp7gxxfrPYb7Cy0mkEADZGSUdE7oOCJzkzUsbRFeqayyG8fm4
OOtqcE0Z/Yf9QF1lebOYTMQFhig9c40v40ewnxLucxkJEcYuNcg/SNyzRlbK7AKg
pGejhkWRU16FTRkR6C8caAj0MUkITqhSp7N4VOU/K5ZOwO6n6vyiza81lbNPSRG9
qCHLy+IppN0KC0SMhfQ5Kd+3U+LEHaCAJ5p7KnrtFAfAEfCcVRyKMXrO2RFXKUPW
1QIDAQAB
-----END PUBLIC KEY-----
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
