### PR TITLE
Add Http_Content_Length to env variables

### DIFF
--- a/watchdog/handler.go
+++ b/watchdog/handler.go
@@ -228,7 +228,7 @@ func getAdditionalEnvs(config *WatchdogConfig, r *http.Request, method string) [
 		}
 
 		envs = append(envs, fmt.Sprintf("Http_Method=%s", method))
-		// DEPRECATED: Http_ContentLength will be deprecated in favour
+		// Deprecation notice: Http_ContentLength will be deprecated
 		envs = append(envs, fmt.Sprintf("Http_ContentLength=%d", r.ContentLength))
 		envs = append(envs, fmt.Sprintf("Http_Content_Length=%d", r.ContentLength))
 

--- a/watchdog/handler.go
+++ b/watchdog/handler.go
@@ -228,7 +228,9 @@ func getAdditionalEnvs(config *WatchdogConfig, r *http.Request, method string) [
 		}
 
 		envs = append(envs, fmt.Sprintf("Http_Method=%s", method))
+		// DEPRECATED: Http_ContentLength will be deprecated in favour
 		envs = append(envs, fmt.Sprintf("Http_ContentLength=%d", r.ContentLength))
+		envs = append(envs, fmt.Sprintf("Http_Content_Length=%d", r.ContentLength))
 
 		if config.writeDebug {
 			log.Println("Query ", r.URL.RawQuery)

--- a/watchdog/requesthandler_test.go
+++ b/watchdog/requesthandler_test.go
@@ -55,6 +55,9 @@ func TestHandler_HasCustomHeaderInFunction_WithCgi_Mode(t *testing.T) {
 	if !strings.Contains(val, "Http_ContentLength=0") {
 		t.Errorf(config.faasProcess+" should print: Http_ContentLength=0, got: %s\n", val)
 	}
+	if !strings.Contains(val, "Http_Content_Length=0") {
+		t.Errorf(config.faasProcess+" should print: Http_Content_Length=0, got: %s\n", val)
+	}
 	if !strings.Contains(val, "Http_Custom_Header") {
 		t.Errorf(config.faasProcess+" should print: Http_Custom_Header, got: %s\n", val)
 	}
@@ -93,6 +96,9 @@ func TestHandler_HasCustomHeaderInFunction_WithCgiMode_AndBody(t *testing.T) {
 	val := string(read)
 	if !strings.Contains(val, fmt.Sprintf("Http_ContentLength=%d", len(body))) {
 		t.Errorf("'env' should printed: Http_ContentLength=0, got: %s\n", val)
+	}
+	if !strings.Contains(val, fmt.Sprintf("Http_Content_Length=%d", len(body))) {
+		t.Errorf("'env' should printed: Http_Content_Length=0, got: %s\n", val)
 	}
 	if !strings.Contains(val, "Http_Custom_Header") {
 		t.Errorf("'env' should printed: Http_Custom_Header, got: %s\n", val)


### PR DESCRIPTION
Http_ContentLengh will be deprecated in the future.

Signed-off-by: Matias Pan <matias.pan26@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As discussed in #1127 this PR adds the environment variable `Http_Content_Length` but keeps `Http_ContentLength` to not introduce a breaking change. `Http_ContentLength` is considered deprecated and will be removed in the future.

Fixes #1127 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I built the watchdog, created a new function using it and tested that the contents of `Http_Content_Length` was being set correctly.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
