### PR TITLE
Bundle watchdog binaries into an image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,25 @@ after_success:
         echo $QUAY_PASSWORD | docker login -u=$QUAY_USERNAME --password-stdin quay.io;
         docker push quay.io/$DOCKER_NS/gateway:$TRAVIS_TAG;
 
-        docker tag $DOCKER_NS/watchdog:latest-dev $DOCKER_NS/watchdog:$TRAVIS_TAG;
+        docker tag $DOCKER_NS/classic-watchdog:latest-dev-armhf $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-armhf;
+        docker tag $DOCKER_NS/classic-watchdog:latest-dev-arm64 $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-arm64;
+        docker tag $DOCKER_NS/classic-watchdog:latest-dev-windows $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-windows;
+        docker tag $DOCKER_NS/classic-watchdog:latest-dev-x86_64 $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-x86_64;
         echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
-        docker push $DOCKER_NS/watchdog:$TRAVIS_TAG;
+        docker push $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-armhf;
+        docker push $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-arm64;
+        docker push $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-windows; 
+        docker push $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-x86_64;
 
-        docker tag $DOCKER_NS/watchdog:latest-dev quay.io/$DOCKER_NS/watchdog:$TRAVIS_TAG;
+        docker tag $DOCKER_NS/classic-watchdog:latest-dev-armhf quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-armhf;
+        docker tag $DOCKER_NS/classic-watchdog:latest-dev-arm64 quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-arm64;
+        docker tag $DOCKER_NS/classic-watchdog:latest-dev-windows quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-windows;
+        docker tag $DOCKER_NS/classic-watchdog:latest-dev-x86_64 quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-x86_64;
         echo $QUAY_PASSWORD | docker login -u=$QUAY_USERNAME --password-stdin quay.io;
-        docker push quay.io/$DOCKER_NS/watchdog:$TRAVIS_TAG;
+        docker push quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-armhf;
+        docker push quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-arm64;
+        docker push quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-windows; 
+        docker push quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-x86_64;
 
         fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,14 @@ after_success:
         echo $QUAY_PASSWORD | docker login -u=$QUAY_USERNAME --password-stdin quay.io;
         docker push quay.io/$DOCKER_NS/gateway:$TRAVIS_TAG;
 
+        docker tag $DOCKER_NS/watchdog:latest-dev $DOCKER_NS/watchdog:$TRAVIS_TAG;
+        echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
+        docker push $DOCKER_NS/watchdog:$TRAVIS_TAG;
+
+        docker tag $DOCKER_NS/watchdog:latest-dev quay.io/$DOCKER_NS/watchdog:$TRAVIS_TAG;
+        echo $QUAY_PASSWORD | docker login -u=$QUAY_USERNAME --password-stdin quay.io;
+        docker push quay.io/$DOCKER_NS/watchdog:$TRAVIS_TAG;
+
         fi
 
 before_deploy:

--- a/watchdog/Dockerfile.packager
+++ b/watchdog/Dockerfile.packager
@@ -1,7 +1,6 @@
 FROM openfaas/watchdog:build as build
 FROM scratch
 
-COPY --from=build /go/src/github.com/openfaas/faas/watchdog/watchdog ./fwatchdog
-COPY --from=build /go/src/github.com/openfaas/faas/watchdog/watchdog-armhf ./fwatchdog-armhf
-COPY --from=build /go/src/github.com/openfaas/faas/watchdog/watchdog-arm64 ./fwatchdog-arm64
-COPY --from=build /go/src/github.com/openfaas/faas/watchdog/watchdog.exe ./fwatchdog.exe
+ARG PLATFORM
+
+COPY --from=build /go/src/github.com/openfaas/faas/watchdog/watchdog$PLATFORM ./fwatchdog

--- a/watchdog/Dockerfile.packager
+++ b/watchdog/Dockerfile.packager
@@ -1,0 +1,7 @@
+FROM openfaas/watchdog:build as build
+FROM scratch
+
+COPY --from=build /go/src/github.com/openfaas/faas/watchdog/watchdog ./fwatchdog
+COPY --from=build /go/src/github.com/openfaas/faas/watchdog/watchdog-armhf ./fwatchdog-armhf
+COPY --from=build /go/src/github.com/openfaas/faas/watchdog/watchdog-arm64 ./fwatchdog-arm64
+COPY --from=build /go/src/github.com/openfaas/faas/watchdog/watchdog.exe ./fwatchdog.exe

--- a/watchdog/build.sh
+++ b/watchdog/build.sh
@@ -22,6 +22,8 @@ else
     docker build --no-cache --build-arg VERSION=$VERSION --build-arg GIT_COMMIT=$GIT_COMMIT -t openfaas/watchdog:build .
 fi
 
+docker build --no-cache -t openfaas/watchdog:latest-dev . -f Dockerfile.packager
+
 docker create --name buildoutput openfaas/watchdog:build echo
 
 docker cp buildoutput:/go/src/github.com/openfaas/faas/watchdog/watchdog ./fwatchdog
@@ -30,4 +32,3 @@ docker cp buildoutput:/go/src/github.com/openfaas/faas/watchdog/watchdog-arm64 .
 docker cp buildoutput:/go/src/github.com/openfaas/faas/watchdog/watchdog.exe ./fwatchdog.exe
 
 docker rm buildoutput
-

--- a/watchdog/build.sh
+++ b/watchdog/build.sh
@@ -22,7 +22,10 @@ else
     docker build --no-cache --build-arg VERSION=$VERSION --build-arg GIT_COMMIT=$GIT_COMMIT -t openfaas/watchdog:build .
 fi
 
-docker build --no-cache -t openfaas/watchdog:latest-dev . -f Dockerfile.packager
+docker build --no-cache --build-arg PLATFORM="-armhf" -t openfaas/classic-watchdog:latest-dev-armhf . -f Dockerfile.packager
+docker build --no-cache --build-arg PLATFORM="-arm64" -t openfaas/classic-watchdog:latest-dev-arm64 . -f Dockerfile.packager
+docker build --no-cache --build-arg PLATFORM=".exe" -t openfaas/classic-watchdog:latest-dev-windows . -f Dockerfile.packager
+docker build --no-cache --build-arg PLATFORM="" -t openfaas/classic-watchdog:latest-dev-x86_64 . -f Dockerfile.packager
 
 docker create --name buildoutput openfaas/watchdog:build echo
 


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
Adds a packager Dockerfile to create an image that contains the fwatchdog binaries.

## Motivation and Context
Fixes #969 

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label

## How Has This Been Tested?
Successfully ran locally.
CI passed

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
