### PR TITLE
Correct swagger Request description for /system/alert

### DIFF
--- a/api-docs/swagger.yml
+++ b/api-docs/swagger.yml
@@ -101,7 +101,7 @@ paths:
       parameters:
       - in: body
         name: body
-        description: Function to delete
+        description: Incoming alert
         schema:
           type: object
           example: |-


### PR DESCRIPTION
Fixed request body description for `POST /system/alert`.

Hope the new description is accurate, I couldn't give to much details, I'm just starting to look into openfaas 😉 

Resolves #1168 