### PR TITLE
Ensure contib prom docker tags match the installed version

### DIFF
--- a/contrib/alertmanager-armhf/0.16.1/Makefile
+++ b/contrib/alertmanager-armhf/0.16.1/Makefile
@@ -3,8 +3,8 @@ all: ci-armhf-build ci-armhf-push
 
 .PHONY: ci-armhf-build
 ci-armhf-build:
-	docker build -t functions/alertmanager:0.15.0-armhf .
+	docker build -t functions/alertmanager:0.16.1-armhf .
 
 .PHONY: ci-armhf-push
 ci-armhf-push:
-	docker push functions/alertmanager:0.15.0-armhf
+	docker push functions/alertmanager:0.16.1-armhf

--- a/contrib/prometheus-armhf/2.2/Makefile
+++ b/contrib/prometheus-armhf/2.2/Makefile
@@ -1,3 +1,3 @@
 build:
-	docker build -t alexellis2/prometheus:2.3.1-armhf .
+	docker build -t alexellis2/prometheus:2.2.0-armhf .
 

--- a/contrib/prometheus-armhf/2.7.1/Makefile
+++ b/contrib/prometheus-armhf/2.7.1/Makefile
@@ -3,8 +3,8 @@ all: ci-armhf-build ci-armhf-push
 
 .PHONY: ci-armhf-build
 ci-armhf-build:
-	docker build -t functions/prometheus:2.7.0-armhf .
+	docker build -t functions/prometheus:2.7.1-armhf .
 
 .PHONY: ci-armhf-push
 ci-armhf-push:
-	docker push functions/prometheus:2.7.0-armhf
+	docker push functions/prometheus:2.7.1-armhf


### PR DESCRIPTION
## Description
- For each prometheus and alert manager contrib makefile, ensure that
the docker tag matches the version installed in the dockerfile.  This
will ensure that no one pushes mismatched versions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label

Resolves #1172 
Relates to https://github.com/openfaas/faas-netes/pull/425

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the makefiles locally to ensure that the resulting tag was passed correctly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
