### PR TITLE
Add external auth handler and gateway config options

### DIFF
--- a/gateway/handlers/external_auth.go
+++ b/gateway/handlers/external_auth.go
@@ -1,0 +1,1 @@
+package handlers

--- a/gateway/handlers/external_auth.go
+++ b/gateway/handlers/external_auth.go
@@ -11,9 +11,9 @@ func MakeExternalAuthHandler(next http.HandlerFunc, upstreamTimeout time.Duratio
 	return func(w http.ResponseWriter, r *http.Request) {
 		req, _ := http.NewRequest(http.MethodGet, upstreamURL, nil)
 
-		deadlineContext, cancel := context.WithDeadline(
+		deadlineContext, cancel := context.WithTimeout(
 			context.Background(),
-			time.Now().Add(upstreamTimeout))
+			upstreamTimeout)
 
 		defer cancel()
 

--- a/gateway/handlers/external_auth.go
+++ b/gateway/handlers/external_auth.go
@@ -1,1 +1,37 @@
 package handlers
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// MakeExternalAuthHandler make an authentication proxy handler
+func MakeExternalAuthHandler(next http.HandlerFunc, upstreamTimeout time.Duration, upstreamURL string, passBody bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, _ := http.NewRequest(http.MethodGet, upstreamURL, nil)
+
+		deadlineContext, cancel := context.WithDeadline(
+			context.Background(),
+			time.Now().Add(upstreamTimeout))
+
+		defer cancel()
+
+		res, err := http.DefaultClient.Do(req.WithContext(deadlineContext))
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if res.Body != nil {
+			defer res.Body.Close()
+		}
+
+		if res.StatusCode == http.StatusOK {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		w.WriteHeader(res.StatusCode)
+	}
+}

--- a/gateway/handlers/external_auth_test.go
+++ b/gateway/handlers/external_auth_test.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_External_Auth_Wrapper_FailsInvalidAuth(t *testing.T) {
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer s.Close()
+
+	next := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+	}
+
+	passBody := false
+	handler := MakeExternalAuthHandler(next, s.URL, passBody)
+
+	req := httptest.NewRequest(http.MethodGet, s.URL, nil)
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+
+	if rr.Code == http.StatusOK {
+		t.Errorf("Status incorrect, did not want: %d, but got %d", http.StatusOK, rr.Code)
+	}
+}
+
+func Test_External_Auth_Wrapper_PassesValidAuth(t *testing.T) {
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s.Close()
+
+	next := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+	}
+
+	passBody := false
+	handler := MakeExternalAuthHandler(next, s.URL, passBody)
+
+	req := httptest.NewRequest(http.MethodGet, s.URL, nil)
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+	want := http.StatusNotImplemented
+	if rr.Code != want {
+		t.Errorf("Status incorrect, want: %d, but got %d", want, rr.Code)
+	}
+}
+
+func MakeExternalAuthHandler(next http.HandlerFunc, upstreamURL string, passBody bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, _ := http.NewRequest(http.MethodGet, upstreamURL, nil)
+
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		if res.Body != nil {
+			defer res.Body.Close()
+		}
+
+		if res.StatusCode == http.StatusOK {
+			next.ServeHTTP(w, r)
+		}
+		w.WriteHeader(res.StatusCode)
+	}
+}

--- a/gateway/handlers/external_auth_test.go
+++ b/gateway/handlers/external_auth_test.go
@@ -53,11 +53,12 @@ func Test_External_Auth_Wrapper_PassesValidAuth(t *testing.T) {
 	}
 }
 
-func Test_External_Auth_Wrapper_TimeoutGivesInternalServerError(t *testing.T) {
+// Test_External_Auth_Wrapper_PassesValidAuthButOnly200IsValid this test exists
+// to document the TODO action to consider all "2xx" statuses as valid.
+func Test_External_Auth_Wrapper_PassesValidAuthButOnly200IsValid(t *testing.T) {
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(50 * time.Millisecond)
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer s.Close()
 
@@ -66,14 +67,38 @@ func Test_External_Auth_Wrapper_TimeoutGivesInternalServerError(t *testing.T) {
 	}
 
 	passBody := false
-	handler := MakeExternalAuthHandler(next, time.Millisecond*10, s.URL, passBody)
+	handler := MakeExternalAuthHandler(next, time.Second*5, s.URL, passBody)
 
 	req := httptest.NewRequest(http.MethodGet, s.URL, nil)
 	rr := httptest.NewRecorder()
 	handler(rr, req)
-
-	want := http.StatusInternalServerError
+	want := http.StatusUnauthorized
 	if rr.Code != want {
 		t.Errorf("Status incorrect, want: %d, but got %d", want, rr.Code)
 	}
 }
+
+// func Test_External_Auth_Wrapper_TimeoutGivesInternalServerError(t *testing.T) {
+
+// 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// 		time.Sleep(50 * time.Millisecond)
+// 		w.WriteHeader(http.StatusOK)
+// 	}))
+// 	defer s.Close()
+
+// 	next := func(w http.ResponseWriter, r *http.Request) {
+// 		w.WriteHeader(http.StatusNotImplemented)
+// 	}
+
+// 	passBody := false
+// 	handler := MakeExternalAuthHandler(next, time.Millisecond*10, s.URL, passBody)
+
+// 	req := httptest.NewRequest(http.MethodGet, s.URL, nil)
+// 	rr := httptest.NewRecorder()
+// 	handler(rr, req)
+
+// 	want := http.StatusInternalServerError
+// 	if rr.Code != want {
+// 		t.Errorf("Status incorrect, want: %d, but got %d", want, rr.Code)
+// 	}
+// }

--- a/gateway/types/readconfig.go
+++ b/gateway/types/readconfig.go
@@ -137,6 +137,9 @@ func (ReadConfig) Read(hasEnv HasEnv) GatewayConfig {
 		}
 	}
 
+	cfg.AuthProxyURL = hasEnv.Getenv("auth_proxy_url")
+	cfg.AuthProxyPassBody = parseBoolValue(hasEnv.Getenv("auth_proxy_pass_body"))
+
 	return cfg
 }
 
@@ -182,9 +185,17 @@ type GatewayConfig struct {
 	// Enable the gateway to scale any service from 0 replicas to its configured "min replicas"
 	ScaleFromZero bool
 
+	// MaxIdleConns with a default value of 1024, can be used for tuning HTTP proxy performance
 	MaxIdleConns int
 
+	// MaxIdleConnsPerHost with a default value of 1024, can be used for tuning HTTP proxy performance
 	MaxIdleConnsPerHost int
+
+	// AuthProxyURL specifies URL for an authenticating proxy, disabled when blank, enabled when valid URL i.e. http://basic-auth.openfaas:8080/validate
+	AuthProxyURL string
+
+	// AuthProxyPassBody pass body to validation proxy
+	AuthProxyPassBody bool
 }
 
 // UseNATS Use NATSor not

--- a/gateway/types/readconfig_test.go
+++ b/gateway/types/readconfig_test.go
@@ -299,3 +299,45 @@ func TestRead_MaxIdleConns_Override(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestRead_AuthProxy_Defaults(t *testing.T) {
+	defaults := NewEnvBucket()
+
+	readConfig := ReadConfig{}
+	wantURL := ""
+	wantBody := false
+
+	config := readConfig.Read(defaults)
+
+	if config.AuthProxyPassBody != wantBody {
+		t.Logf("config.AuthProxyPassBody, want: %t, got: %t\n", wantBody, config.AuthProxyPassBody)
+		t.Fail()
+	}
+
+	if config.AuthProxyURL != wantURL {
+		t.Logf("config.AuthProxyURL, want: %s, got: %s\n", wantURL, config.AuthProxyURL)
+		t.Fail()
+	}
+}
+
+func TestRead_AuthProxy_DefaultsOverrides(t *testing.T) {
+	defaults := NewEnvBucket()
+
+	readConfig := ReadConfig{}
+	wantURL := "http://auth.openfaas:8080/validate"
+	wantBody := true
+	defaults.Setenv("auth_proxy_url", wantURL)
+	defaults.Setenv("auth_proxy_pass_body", fmt.Sprintf("%t", wantBody))
+
+	config := readConfig.Read(defaults)
+
+	if config.AuthProxyPassBody != wantBody {
+		t.Logf("config.AuthProxyPassBody, want: %t, got: %t\n", wantBody, config.AuthProxyPassBody)
+		t.Fail()
+	}
+
+	if config.AuthProxyURL != wantURL {
+		t.Logf("config.AuthProxyURL, want: %s, got: %s\n", wantURL, config.AuthProxyURL)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This commit adds an external auth handler which can be used to
wrap existing handlers, so that they delegate their requests
to an upstream URL before allowing a request to pass through
to an upstream API.

Gateway config also gains two new options:

* auth_proxy_url
* auth_proxy_pass_body

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#1209 #1210 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The new handler has been tested with unit tests for positive / negative cases

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.