### PR TITLE
Deploy basic auth plugin

### DIFF
--- a/deploy_stack.sh
+++ b/deploy_stack.sh
@@ -6,6 +6,7 @@ if ! [ -x "$(command -v docker)" ]; then
 fi
 
 export BASIC_AUTH="true"
+export AUTH_URL="http://basic-auth-plugin:8080/validate"
 
 sha_cmd="shasum -a 256"
 if ! command -v shasum >/dev/null; then
@@ -17,6 +18,7 @@ do
 	case "$1" in
 		--no-auth | -n)
 			export BASIC_AUTH="false"
+      export AUTH_URL=""
 			;;
     --help | -h)
 			echo "Usage: \n [default]\tdeploy the OpenFaaS core services\n --no-auth [-n]\tdisable basic authentication.\n --help\tdisplays this screen"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.12.0
+        image: openfaas/gateway:0.13.6
         networks:
             - functions
         environment:
@@ -21,6 +21,8 @@ services:
             scale_from_zero: "true" # Enable if you want functions to scale from 0/0 to min replica count upon invoke
             max_idle_conns: 1024
             max_idle_conns_per_host: 1024
+            auth_proxy_url: "${AUTH_URL:-}"
+            auth_proxy_pass_body: "false"
         deploy:
             resources:
                 # limits:   # Enable if you want to limit memory usage
@@ -35,6 +37,32 @@ services:
             placement:
                 constraints:
                     - "node.platform.os == linux"
+        secrets:
+            - basic-auth-user
+            - basic-auth-password
+
+    # auth service provide basic-auth plugin for system APIs
+    basic-auth-plugin:
+        image: openfaas/basic-auth-plugin:0.1.0
+        networks:
+            - functions
+        environment:
+            secret_mount_path: "/run/secrets/"
+        deploy:
+            placement:
+                constraints:
+                    - "node.role == manager"
+                    - "node.platform.os == linux"
+            resources:
+                # limits:   # Enable if you want to limit memory usage
+                #     memory: 100M
+                reservations:
+                    memory: 50M
+            restart_policy:
+                condition: on-failure
+                delay: 5s
+                max_attempts: 20
+                window: 380s
         secrets:
             - basic-auth-user
             - basic-auth-password


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As part of #1209, this change deploys, but does not enable the
new basic-auth plugin service.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#1209 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deploying to Swarm with the edited ./deploy_stack.sh - and seeing the service available.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
