### PR TITLE
Switch gateway to external auth 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.13.6
+        image: openfaas/gateway:0.13.7-rc2
         networks:
             - functions
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.13.7-rc4
+        image: openfaas/gateway:0.13.7-rc5
         networks:
             - functions
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.13.7-rc2
+        image: openfaas/gateway:0.13.7-rc4
         networks:
             - functions
         environment:
@@ -43,11 +43,13 @@ services:
 
     # auth service provide basic-auth plugin for system APIs
     basic-auth-plugin:
-        image: openfaas/basic-auth-plugin:0.1.0
+        image: openfaas/basic-auth-plugin:0.1.1
         networks:
             - functions
         environment:
             secret_mount_path: "/run/secrets/"
+            user_filename: "basic-auth-user"
+            pass_filename: "basic-auth-password"
         deploy:
             placement:
                 constraints:

--- a/gateway/handlers/basic_auth_injector.go
+++ b/gateway/handlers/basic_auth_injector.go
@@ -1,0 +1,20 @@
+// Copyright (c) OpenFaaS Author(s). All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/openfaas/faas-provider/auth"
+)
+
+type BasicAuthInjector struct {
+	Credentials *auth.BasicAuthCredentials
+}
+
+func (b BasicAuthInjector) Inject(r *http.Request) {
+	if r != nil && b.Credentials != nil {
+		r.SetBasicAuth(b.Credentials.User, b.Credentials.Password)
+	}
+}

--- a/gateway/handlers/basic_auth_injector_test.go
+++ b/gateway/handlers/basic_auth_injector_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) OpenFaaS Author(s). All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_Inject_WithNilRequestAndNilCredentials(t *testing.T) {
+	injector := BasicAuthInjector{}
+	injector.Inject(nil)
+}
+
+func Test_Inject_WithRequestButNilCredentials(t *testing.T) {
+	injector := BasicAuthInjector{}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	injector.Inject(req)
+}

--- a/gateway/handlers/serviceauthinjector.go
+++ b/gateway/handlers/serviceauthinjector.go
@@ -1,0 +1,7 @@
+package handlers
+
+import "net/http"
+
+type AuthInjector interface {
+	Inject(r *http.Request)
+}

--- a/gateway/plugin/external_test.go
+++ b/gateway/plugin/external_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openfaas/faas-provider/auth"
+	"github.com/openfaas/faas/gateway/handlers"
 	"github.com/openfaas/faas/gateway/scaling"
 )
 
@@ -47,11 +47,10 @@ func TestGetReplicasNonExistentFn(t *testing.T) {
 		}))
 	defer testServer.Close()
 
-	var creds auth.BasicAuthCredentials
-
+	var injector handlers.AuthInjector
 	url, _ := url.Parse(testServer.URL + "/")
 
-	esq := NewExternalServiceQuery(*url, &creds)
+	esq := NewExternalServiceQuery(*url, injector)
 
 	svcQryResp, err := esq.GetReplicas("burt")
 
@@ -78,11 +77,10 @@ func TestGetReplicasExistentFn(t *testing.T) {
 		AvailableReplicas: 0,
 	}
 
-	var creds auth.BasicAuthCredentials
-
+	var injector handlers.AuthInjector
 	url, _ := url.Parse(testServer.URL + "/")
 
-	esq := NewExternalServiceQuery(*url, &creds)
+	esq := NewExternalServiceQuery(*url, injector)
 
 	svcQryResp, err := esq.GetReplicas("burt")
 
@@ -104,9 +102,9 @@ func TestSetReplicasNonExistentFn(t *testing.T) {
 		}))
 	defer testServer.Close()
 
-	var creds auth.BasicAuthCredentials
+	var injector handlers.AuthInjector
 	url, _ := url.Parse(testServer.URL + "/")
-	esq := NewExternalServiceQuery(*url, &creds)
+	esq := NewExternalServiceQuery(*url, injector)
 
 	err := esq.SetReplicas("burt", 1)
 
@@ -126,9 +124,10 @@ func TestSetReplicasExistentFn(t *testing.T) {
 		}))
 	defer testServer.Close()
 
-	var creds auth.BasicAuthCredentials
+	var injector handlers.AuthInjector
+
 	url, _ := url.Parse(testServer.URL + "/")
-	esq := NewExternalServiceQuery(*url, &creds)
+	esq := NewExternalServiceQuery(*url, injector)
 
 	err := esq.SetReplicas("burt", 1)
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -89,7 +89,11 @@ func main() {
 		functionURLTransformer = nilURLTransformer
 	}
 
-	serviceAuthInjector := &BasicAuthInjector{Credentials: credentials}
+	var serviceAuthInjector handlers.AuthInjector
+
+	if config.UseBasicAuth {
+		serviceAuthInjector = &handlers.BasicAuthInjector{Credentials: credentials}
+	}
 
 	decorateExternalAuth := handlers.MakeExternalAuthHandler
 
@@ -256,12 +260,4 @@ func runMetricsServer() {
 	}
 
 	log.Fatal(s.ListenAndServe())
-}
-
-type BasicAuthInjector struct {
-	Credentials *auth.BasicAuthCredentials
-}
-
-func (b BasicAuthInjector) Inject(r *http.Request) {
-	r.SetBasicAuth(b.Credentials.User, b.Credentials.Password)
 }

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -83,6 +83,8 @@ func main() {
 		functionURLTransformer = nilURLTransformer
 	}
 
+	decorateExternalAuth := handlers.MakeExternalAuthHandler
+
 	faasHandlers.Proxy = handlers.MakeForwardingProxyHandler(reverseProxy, functionNotifiers, functionURLResolver, functionURLTransformer)
 
 	faasHandlers.RoutelessProxy = handlers.MakeForwardingProxyHandler(reverseProxy, forwardingNotifiers, urlResolver, nilURLTransformer)
@@ -131,25 +133,25 @@ func main() {
 
 	if credentials != nil {
 		faasHandlers.Alert =
-			auth.DecorateWithBasicAuth(faasHandlers.Alert, credentials)
+			decorateExternalAuth(faasHandlers.Alert, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)
 		faasHandlers.UpdateFunction =
-			auth.DecorateWithBasicAuth(faasHandlers.UpdateFunction, credentials)
+			decorateExternalAuth(faasHandlers.UpdateFunction, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)
 		faasHandlers.DeleteFunction =
-			auth.DecorateWithBasicAuth(faasHandlers.DeleteFunction, credentials)
+			decorateExternalAuth(faasHandlers.DeleteFunction, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)
 		faasHandlers.DeployFunction =
-			auth.DecorateWithBasicAuth(faasHandlers.DeployFunction, credentials)
+			decorateExternalAuth(faasHandlers.DeployFunction, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)
 		faasHandlers.ListFunctions =
-			auth.DecorateWithBasicAuth(faasHandlers.ListFunctions, credentials)
+			decorateExternalAuth(faasHandlers.ListFunctions, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)
 		faasHandlers.ScaleFunction =
-			auth.DecorateWithBasicAuth(faasHandlers.ScaleFunction, credentials)
+			decorateExternalAuth(faasHandlers.ScaleFunction, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)
 		faasHandlers.QueryFunction =
-			auth.DecorateWithBasicAuth(faasHandlers.QueryFunction, credentials)
+			decorateExternalAuth(faasHandlers.QueryFunction, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)
 		faasHandlers.InfoHandler =
-			auth.DecorateWithBasicAuth(faasHandlers.InfoHandler, credentials)
+			decorateExternalAuth(faasHandlers.InfoHandler, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)
 		faasHandlers.AsyncReport =
-			auth.DecorateWithBasicAuth(faasHandlers.AsyncReport, credentials)
+			decorateExternalAuth(faasHandlers.AsyncReport, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)
 		faasHandlers.SecretHandler =
-			auth.DecorateWithBasicAuth(faasHandlers.SecretHandler, credentials)
+			decorateExternalAuth(faasHandlers.SecretHandler, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)
 	}
 
 	r := mux.NewRouter()
@@ -201,7 +203,7 @@ func main() {
 
 	uiHandler := http.StripPrefix("/ui", fsCORS)
 	if credentials != nil {
-		r.PathPrefix("/ui/").Handler(auth.DecorateWithBasicAuth(uiHandler.ServeHTTP, credentials)).Methods(http.MethodGet)
+		r.PathPrefix("/ui/").Handler(decorateExternalAuth(uiHandler.ServeHTTP, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)).Methods(http.MethodGet)
 	} else {
 		r.PathPrefix("/ui/").Handler(uiHandler).Methods(http.MethodGet)
 	}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -95,7 +95,6 @@ func main() {
 
 	faasHandlers.Proxy = handlers.MakeForwardingProxyHandler(reverseProxy, functionNotifiers, functionURLResolver, functionURLTransformer, nil)
 
-	faasHandlers.RoutelessProxy = handlers.MakeForwardingProxyHandler(reverseProxy, forwardingNotifiers, urlResolver, nilURLTransformer, serviceAuthInjector)
 	faasHandlers.ListFunctions = handlers.MakeForwardingProxyHandler(reverseProxy, forwardingNotifiers, urlResolver, nilURLTransformer, serviceAuthInjector)
 	faasHandlers.DeployFunction = handlers.MakeForwardingProxyHandler(reverseProxy, forwardingNotifiers, urlResolver, nilURLTransformer, serviceAuthInjector)
 	faasHandlers.DeleteFunction = handlers.MakeForwardingProxyHandler(reverseProxy, forwardingNotifiers, urlResolver, nilURLTransformer, serviceAuthInjector)

--- a/gateway/types/handler_set.go
+++ b/gateway/types/handler_set.go
@@ -4,12 +4,14 @@ import "net/http"
 
 // HandlerSet can be initialized with handlers for binding to mux
 type HandlerSet struct {
-	Proxy          http.HandlerFunc
+	// Proxy invokes functions upstream
+	Proxy http.HandlerFunc
+
 	DeployFunction http.HandlerFunc
 	DeleteFunction http.HandlerFunc
 	ListFunctions  http.HandlerFunc
 	Alert          http.HandlerFunc
-	RoutelessProxy http.HandlerFunc
+
 	UpdateFunction http.HandlerFunc
 
 	// QueryFunction - queries the metdata for a function


### PR DESCRIPTION
Switch gateway to external auth

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This commit moves the OpenFaaS gateway from using in-process
basic-auth for everything to use an external auth URL instead.

When auth is not enable, this functionality is not added to the
handlers and behaves as before. When enabled, the configured
plugin with authenticate requests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#1209 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested e2e on Docker Swarm with positive and negative tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
