### PR TITLE
Remove extra customize button

### DIFF
--- a/gateway/assets/script/bootstrap.js
+++ b/gateway/assets/script/bootstrap.js
@@ -282,10 +282,6 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$interval', '$f
 
                 $scope.selectedFunc = func;
             }
-
-            $scope.customizeStoreFunc = function() {
-                $scope.selectedTabIdx = CUSTOM_DEPLOY_TAB_INDEX;
-            }
             
             $scope.onTabSelect = function(idx) {
                 newFuncTabIdx = idx;

--- a/gateway/assets/templates/newfunction.html
+++ b/gateway/assets/templates/newfunction.html
@@ -162,9 +162,6 @@
         <md-button ng-click="closeDialog()" class="md-secondary">
             Close Dialog
         </md-button>
-        <md-button ng-if="selectedFunc" ng-click="customizeStoreFunc()" class="md-warn">
-            Customize
-        </md-button>
         <md-button ng-disabled="userForm.$invalid" ng-click="createFunc()" class="md-primary">
             Deploy
         </md-button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The customize button was redundant to the custom tab
This could lead to confusion with the user experience,
so the additional button has been removed.

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [X] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed new version of the gateway locally, and confirmed button is no longer present, and function deployments still function as expected.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This is in response to https://github.com/openfaas/faas/pull/1189#issuecomment-497682330

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
