### PR TITLE
## nmap -A baidu.com

### DIFF
--- a/sample-functions/Nmap/Dockerfile
+++ b/sample-functions/Nmap/Dockerfile
@@ -1,8 +1,13 @@
 FROM functions/alpine:latest
 
-RUN apk add --no-cache nmap
+## nmap -A baidu.com
+## when run nmap with `-A` argument
+## if not install nmap-scripts will cause error:
+##
+##  NSE: failed to initialize the script engine:
+##  could not locate nse_main.lua
+##
 
-ENV fprocess="xargs nmap"
+RUN apk add --no-cache nmap nmap-scripts
 
-
-CMD ["fwatchdog"]
+ENV fprocess="xargs nmap"	ENV fprocess="xargs nmap"


### PR DESCRIPTION
 when run nmap with `-A` argument
 if not install nmap-scripts will cause error:
```
  NSE: failed to initialize the script engine:
  could not locate nse_main.lua
```

Signed-off-by: chennqqi <chennqqi@qq.com>

support map `-A` argument

## Description

without install nmap-script `nmap -A` will run failed

## Motivation and Context

support for full feature nmap function

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- [x ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label

## How Has This Been Tested?

1. Deployed nmap via UI
2. Enter `-A www.baidu.com` or some other real domain/ip `-A 10.0.0.1`
 nmap will show message
image
![image](https://user-images.githubusercontent.com/5073720/59766179-2dc23300-92d2-11e9-8f42-cafcb6e85e42.png)
3. enter into docker, then run `apk add --no-cache nmap-scripts`
4. redo step 1 you will see `nmap -A` run sucessfully

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
