### PR TITLE
Refactor CI and enable auto-builds for auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,37 +26,18 @@ after_success:
     - if [ ! -z "$TRAVIS_TAG" ] ; then
         export DOCKER_CLI_EXPERIMENTAL=enabled
 
-        docker tag $DOCKER_NS/gateway:latest-dev $DOCKER_NS/gateway:$TRAVIS_TAG;
         echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
-        docker push $DOCKER_NS/gateway:$TRAVIS_TAG;
-
-        docker tag $DOCKER_NS/gateway:latest-dev quay.io/$DOCKER_NS/gateway:$TRAVIS_TAG;
         echo $QUAY_PASSWORD | docker login -u=$QUAY_USERNAME --password-stdin quay.io;
-        docker push quay.io/$DOCKER_NS/gateway:$TRAVIS_TAG;
-
-        docker tag $DOCKER_NS/classic-watchdog:latest-dev-armhf $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-armhf;
-        docker tag $DOCKER_NS/classic-watchdog:latest-dev-arm64 $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-arm64;
-        docker tag $DOCKER_NS/classic-watchdog:latest-dev-windows $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-windows;
-        docker tag $DOCKER_NS/classic-watchdog:latest-dev-x86_64 $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-x86_64;
-        echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
-        docker push $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-armhf;
-        docker push $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-arm64;
-        docker push $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-windows; 
-        docker push $DOCKER_NS/classic-watchdog:$TRAVIS_TAG-x86_64;
-
-        docker tag $DOCKER_NS/classic-watchdog:latest-dev-armhf quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-armhf;
-        docker tag $DOCKER_NS/classic-watchdog:latest-dev-arm64 quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-arm64;
-        docker tag $DOCKER_NS/classic-watchdog:latest-dev-windows quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-windows;
-        docker tag $DOCKER_NS/classic-watchdog:latest-dev-x86_64 quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-x86_64;
+        
+        ./ci/tagAndPush.sh "$DOCKER_NS/gateway";
+        ./ci/tagAndPush.sh "$DOCKER_NS/basic-auth-plugin";
+        ./ci/tagAndPush.sh "$DOCKER_NS/classic-watchdog" armhf;
+        ./ci/tagAndPush.sh "$DOCKER_NS/classic-watchdog" arm64;
+        ./ci/tagAndPush.sh "$DOCKER_NS/classic-watchdog" windows;
+        ./ci/tagAndPush.sh "$DOCKER_NS/classic-watchdog" x86_64;
 
         ./watchdog/make_manifest.sh
         docker push $DOCKER_NS/classic-watchdog:$TRAVIS_TAG
-
-        echo $QUAY_PASSWORD | docker login -u=$QUAY_USERNAME --password-stdin quay.io;
-        docker push quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-armhf;
-        docker push quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-arm64;
-        docker push quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-windows; 
-        docker push quay.io/$DOCKER_NS/classic-watchdog:$TRAVIS_TAG-x86_64;
 
         fi
 

--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,16 @@ test-ci:
 
 .PHONY: ci-armhf-build
 ci-armhf-build:
-	(cd gateway; ./build.sh $(TAG))
+	(cd gateway; ./build.sh $(TAG) ; cd ../auth/basic-auth ; ./build.sh $(TAG))
 
 .PHONY: ci-armhf-push
 ci-armhf-push:
-	(cd gateway; ./push.sh $(TAG))
+	(cd gateway; ./push.sh $(TAG) ; cd ../auth/basic-auth ; ./push.sh $(TAG))
 
 .PHONY: ci-arm64-build
 ci-arm64-build:
-	(cd gateway; ./build.sh $(TAG))
+	(cd gateway; ./build.sh $(TAG) ; cd ../auth/basic-auth ; ./build.sh $(TAG))
 
 .PHONY: ci-arm64-push
 ci-arm64-push:
-	(cd gateway; ./push.sh $(TAG))
+	(cd gateway; ./push.sh $(TAG) ; cd ../auth/basic-auth ; ./push.sh $(TAG))

--- a/auth/basic-auth/Makefile
+++ b/auth/basic-auth/Makefile
@@ -2,4 +2,4 @@ TAG?=latest
 
 .PHONY: build
 build:
-	docker build -t openfaas/basic-auth-plugin:${TAG} .
+	./build.sh ${TAG}

--- a/auth/basic-auth/build.sh
+++ b/auth/basic-auth/build.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -e
+
+export arch=$(uname -m)
+export eTAG="latest-dev"
+
+if [ "$arch" = "armv7l" ] ; then
+   eTAG="latest-armhf-dev"
+elif [ "$arch" = "aarch64" ] ; then
+   eTAG="latest-arm64-dev"
+fi
+
+echo "$1"
+if [ "$1" ] ; then
+  eTAG=$1
+  if [ "$arch" = "armv7l" ] ; then
+    eTAG="$1-armhf"
+  elif [ "$arch" = "aarch64" ] ; then
+    eTAG="$1-arm64"
+  fi
+fi
+
+NS=openfaas
+
+echo Building $NS/basic-auth-plugin:$eTAG
+
+docker build -t $NS/basic-auth-plugin:$eTAG .

--- a/auth/basic-auth/push.sh
+++ b/auth/basic-auth/push.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -e
+
+export arch=$(uname -m)
+export eTAG="latest-dev"
+
+if [ "$arch" = "armv7l" ] ; then
+   eTAG="latest-armhf-dev"
+elif [ "$arch" = "aarch64" ] ; then
+   eTAG="latest-arm64-dev"
+fi
+
+echo "$1"
+if [ "$1" ] ; then
+  eTAG=$1
+  if [ "$arch" = "armv7l" ] ; then
+    eTAG="$1-armhf"
+  elif [ "$arch" = "aarch64" ] ; then
+    eTAG="$1-arm64"
+  fi
+fi
+
+NS=openfaas
+
+echo Pushing $NS/basic-auth-plugin:$eTAG
+
+docker push $NS/basic-auth-plugin:$eTAG

--- a/build.sh
+++ b/build.sh
@@ -7,3 +7,4 @@ fi
 
 (cd gateway && ./build.sh)
 (cd watchdog && ./build.sh)
+(cd auth/basic-auth && ./build.sh)

--- a/ci/tagAndPush.sh
+++ b/ci/tagAndPush.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+IMAGE_NAME=$1
+PLATFORM=""
+
+if [ ! -z "$2" ]; then
+ PLATFORM="-$2"
+fi
+
+echo "Tagging $IMAGE_NAME:$TRAVIS_TAG$PLATFORM"
+docker tag $IMAGE_NAME:latest-dev$PLATFORM $IMAGE_NAME:$TRAVIS_TAG$PLATFORM;
+docker tag $IMAGE_NAME:latest-dev$PLATFORM quay.io/$IMAGE_NAME:$TRAVIS_TAG$PLATFORM;
+
+echo "Pushing $IMAGE_NAME:$TRAVIS_TAG$PLATFORM"
+docker push $IMAGE_NAME:$TRAVIS_TAG$PLATFORM;
+docker push quay.io/$IMAGE_NAME:$TRAVIS_TAG$PLATFORM;


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
Automatic builds for auth-module on x86_64 (via Travis) and on-demand on-device for arm via publish.sh

The basic-auth module is not built or pushed upon 'tag' / 'release' of the faas repo, but it should be: https://github.com/openfaas/faas/tree/master/auth.  We also don't create on-device images for this, but should do for both armhf and arm64: https://github.com/openfaas/faas/blob/master/contrib/publish-arm.sh

This change addresses these challenges and also introduces a tagAndPush script to alleviate some of the recently introduced repetition in .travis.yml.

The new build and push files for the auth plugin follow the pattern established for the gateway component.  The top level Makefile has calls to the new scripts added in the relevant `ci-arm*` definitions.

As the relationship between repos and images has shifted from 1:1 to 1:n, `publish-arm.sh` has been amended to accommodate 1:n.  The has been achieved by changing `get_repo_name()` to `get_image_names()` which effectively returns an array instead of a string.  The looping sections have been amended accordingly. 

## Motivation and Context
Fixes #1231 
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
CI passes on commit
CI fails on release owing to the lack of permissions on the OF namespace - this is expected to work on the main repo.

### Running the top level `build.sh` on x86
```
$ ./build.sh

Building openfaas/gateway:latest-dev
Sending build context to Docker daemon  23.42MB
Step 1/31 : FROM golang:1.10.4 as build
 ---> e6d03b940438
Step 2/31 : ARG GIT_COMMIT_SHA
 ---> Running in 8dcd71c1881b
Removing intermediate container 8dcd71c1881b
 ---> 178e98a7d57d
Step 3/31 : ARG GIT_COMMIT_MESSAGE
 ---> Running in 6ab2a14319a9
Removing intermediate container 6ab2a14319a9
 ---> c2a394f15b0d
Step 4/31 : ARG VERSION='dev'
 ---> Running in d8131f6d9312
Removing intermediate container d8131f6d9312
 ---> 24b6c85d6aaf
Step 5/31 : RUN curl -sLSf   https://raw.githubusercontent.com/teamserverless/license-check/master/get.sh | sh   && mv ./license-check /usr/bin/
 ---> Running in 87f00226587b
x86_64
Downloading https://github.com/teamserverless/license-check/releases/download/0.3.1/license-check..
Removing intermediate container 87f00226587b
 ---> 544aa50f0148
Step 6/31 : WORKDIR /go/src/github.com/openfaas/faas/gateway
 ---> Running in 89b18da09c9b
Removing intermediate container 89b18da09c9b
 ---> 23ed20d5d44b
Step 7/31 : COPY vendor         vendor
 ---> 388ed5dc79d9
Step 8/31 : COPY handlers       handlers
 ---> 6fbb2656b401
Step 9/31 : COPY metrics        metrics
 ---> c85a1a8983f0
Step 10/31 : COPY requests       requests
 ---> d96761def519
Step 11/31 : COPY tests          tests
 ---> ddc20bd8991f
Step 12/31 : COPY types          types
 ---> 8b19be1df50b
Step 13/31 : COPY queue          queue
 ---> 5f5643e2e43a
Step 14/31 : COPY plugin         plugin
 ---> 78751778dc02
Step 15/31 : COPY version        version
 ---> f89a185549b4
Step 16/31 : COPY scaling        scaling
 ---> 80da83c5e785
Step 17/31 : COPY server.go      .
 ---> fd3fdfdee335
Step 18/31 : RUN license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Project" "OpenFaaS Authors" "OpenFaaS Author(s)"     && test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"     && go test $(go list ./... | grep -v integration | grep -v /vendor/ | grep -v /template/) -cover     && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w     -X github.com/openfaas/faas/gateway/version.GitCommitSHA=${GIT_COMMIT_SHA}    -X \"github.com/openfaas/faas/gateway/version.GitCommitMessage=${GIT_COMMIT_MESSAGE}\"    -X github.com/openfaas/faas/gateway/version.Version=${VERSION}"     -a -installsuffix cgo -o gateway .
 ---> Running in fc4a96b280db
?       github.com/openfaas/faas/gateway        [no test files]
ok      github.com/openfaas/faas/gateway/handlers       0.070s  coverage: 33.4% of statements
ok      github.com/openfaas/faas/gateway/metrics        0.010s  coverage: 43.9% of statements
ok      github.com/openfaas/faas/gateway/plugin 0.019s  coverage: 79.0% of statements
?       github.com/openfaas/faas/gateway/queue  [no test files]
ok      github.com/openfaas/faas/gateway/requests       0.006s  coverage: 75.0% of statements
ok      github.com/openfaas/faas/gateway/scaling        0.017s  coverage: 23.4% of statements
ok      github.com/openfaas/faas/gateway/types  0.036s  coverage: 79.7% of statements
?       github.com/openfaas/faas/gateway/version        [no test files]
Removing intermediate container fc4a96b280db
 ---> 8febf83336d5
Step 19/31 : FROM alpine:3.9
 ---> 5cb3aa00f899
Step 20/31 : LABEL org.label-schema.license="MIT"     org.label-schema.vcs-url="https://github.com/openfaas/faas"     org.label-schema.vcs-type="Git"     org.label-schema.name="openfaas/faas"     org.label-schema.vendor="openfaas"     org.label-schema.docker.schema-version="1.0"
 ---> Running in 6750f35cb275
Removing intermediate container 6750f35cb275
 ---> 864e9ecbac30
Step 21/31 : RUN addgroup -S app     && adduser -S -g app app     && apk add --no-cache ca-certificates
 ---> Running in 2e5adb4adc77
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/community/x86_64/APKINDEX.tar.gz
(1/1) Installing ca-certificates (20190108-r0)
Executing busybox-1.29.3-r10.trigger
Executing ca-certificates-20190108-r0.trigger
OK: 6 MiB in 15 packages
Removing intermediate container 2e5adb4adc77
 ---> 8445b27ce572
Step 22/31 : WORKDIR /home/app
 ---> Running in 2123fea9222a
Removing intermediate container 2123fea9222a
 ---> 3e0b5f60983e
Step 23/31 : EXPOSE 8080
 ---> Running in a560e4c8dbdd
Removing intermediate container a560e4c8dbdd
 ---> 5efcda688bc4
Step 24/31 : EXPOSE 8082
 ---> Running in abb81e4f197e
Removing intermediate container abb81e4f197e
 ---> 016fd09a0d1e
Step 25/31 : ENV http_proxy      ""
 ---> Running in ea4f2c13a30c
Removing intermediate container ea4f2c13a30c
 ---> 45026d617b6a
Step 26/31 : ENV https_proxy     ""
 ---> Running in 19f3f24fc511
Removing intermediate container 19f3f24fc511
 ---> 9d91686759a6
Step 27/31 : COPY --from=build /go/src/github.com/openfaas/faas/gateway/gateway    .
 ---> fb35faed491d
Step 28/31 : COPY assets     assets
 ---> 688d024bd2f7
Step 29/31 : RUN chown -R app:app ./
 ---> Running in e636f8aa713b
Removing intermediate container e636f8aa713b
 ---> 081680efbd59
Step 30/31 : USER app
 ---> Running in f42504f6cc3c
Removing intermediate container f42504f6cc3c
 ---> 77deed632915
Step 31/31 : CMD ["./gateway"]
 ---> Running in d41e33fbd4a9
Removing intermediate container d41e33fbd4a9
 ---> 4bce317a7db0
Successfully built 4bce317a7db0
Successfully tagged openfaas/gateway:latest-dev
Sending build context to Docker daemon  26.85MB
Step 1/17 : FROM golang:1.10 as build
1.10: Pulling from library/golang
741437d97401: Pull complete 
34d8874714d7: Pull complete 
0a108aa26679: Pull complete 
7f0334c36886: Pull complete 
d35724ed4672: Pull complete 
c0eaf021aeaf: Pull complete 
d3d9c96611f1: Pull complete 
Digest: sha256:6d5e79878a3e4f1b30b7aa4d24fb6ee6184e905a9b172fc72593935633be4c46
Status: Downloaded newer image for golang:1.10
 ---> 6fd1f7edb6ab
Step 2/17 : ARG VERSION
 ---> Running in d69a8f20820e
Removing intermediate container d69a8f20820e
 ---> 70227db9a72f
Step 3/17 : ARG GIT_COMMIT
 ---> Running in ff9fb2241f50
Removing intermediate container ff9fb2241f50
 ---> 8bf7e31309cc
Step 4/17 : RUN mkdir -p /go/src/github.com/openfaas/faas/watchdog
 ---> Running in c5e5ba6a4191
Removing intermediate container c5e5ba6a4191
 ---> 928e985f8944
Step 5/17 : WORKDIR /go/src/github.com/openfaas/faas/watchdog
 ---> Running in d11e6bbda50e
Removing intermediate container d11e6bbda50e
 ---> 230bf9117159
Step 6/17 : COPY vendor                     vendor
 ---> 92f01fa3bfc5
Step 7/17 : COPY metrics                    metrics
 ---> c86b292b4900
Step 8/17 : COPY types                      types
 ---> 3378acf8511b
Step 9/17 : COPY main.go                    .
 ---> 1dba0e7230bf
Step 10/17 : COPY handler.go                            .
 ---> 1c083d064747
Step 11/17 : COPY readconfig.go             .
 ---> 140a50eb094a
Step 12/17 : COPY readconfig_test.go        .
 ---> b9eccbb9aba4
Step 13/17 : COPY requesthandler_test.go        .
 ---> fabed7cddbf9
Step 14/17 : COPY version.go                 .
 ---> cd67c41a8f46
Step 15/17 : RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"
 ---> Running in 9194359e6fe8
Removing intermediate container 9194359e6fe8
 ---> c8fdf1c6d18c
Step 16/17 : RUN go test -v ./...
 ---> Running in 3c612ad65e3f
=== RUN   TestRead_CombineOutput_DefaultTrue
--- PASS: TestRead_CombineOutput_DefaultTrue (0.00s)
=== RUN   TestRead_CombineOutput_OverrideFalse
--- PASS: TestRead_CombineOutput_OverrideFalse (0.00s)
=== RUN   TestRead_CgiHeaders_OverrideFalse
--- PASS: TestRead_CgiHeaders_OverrideFalse (0.00s)
=== RUN   TestRead_CgiHeaders_DefaultIsTrueConfig
--- PASS: TestRead_CgiHeaders_DefaultIsTrueConfig (0.00s)
=== RUN   TestRead_WriteDebug_DefaultIsFalseConfig
--- PASS: TestRead_WriteDebug_DefaultIsFalseConfig (0.00s)
=== RUN   TestRead_WriteDebug_TrueOverrideConfig
--- PASS: TestRead_WriteDebug_TrueOverrideConfig (0.00s)
=== RUN   TestRead_WriteDebug_FlaseConfig
--- PASS: TestRead_WriteDebug_FlaseConfig (0.00s)
=== RUN   TestRead_SuppressLockConfig
--- PASS: TestRead_SuppressLockConfig (0.00s)
=== RUN   TestRead_ContentTypeConfig
--- PASS: TestRead_ContentTypeConfig (0.00s)
=== RUN   TestRead_FprocessConfig
--- PASS: TestRead_FprocessConfig (0.00s)
=== RUN   TestRead_EmptyTimeoutConfig
--- PASS: TestRead_EmptyTimeoutConfig (0.00s)
=== RUN   TestRead_DefaultPortConfig
--- PASS: TestRead_DefaultPortConfig (0.00s)
=== RUN   TestRead_PortConfig
--- PASS: TestRead_PortConfig (0.00s)
=== RUN   TestRead_ReadAndWriteTimeoutConfig
--- PASS: TestRead_ReadAndWriteTimeoutConfig (0.00s)
=== RUN   TestRead_ReadAndWriteTimeoutDurationConfig
--- PASS: TestRead_ReadAndWriteTimeoutDurationConfig (0.00s)
=== RUN   TestRead_ExecTimeoutConfig
--- PASS: TestRead_ExecTimeoutConfig (0.00s)
=== RUN   TestRead_MetricsPort
--- PASS: TestRead_MetricsPort (0.00s)
=== RUN   TestHandler_make
--- PASS: TestHandler_make (0.00s)
=== RUN   TestHandler_HasCustomHeaderInFunction_WithCgi_Mode
2019/06/23 14:59:38 Forking fprocess.
2019/06/23 14:59:38 Wrote 362 Bytes - Duration: 0.001344 seconds
--- PASS: TestHandler_HasCustomHeaderInFunction_WithCgi_Mode (0.00s)
=== RUN   TestHandler_HasCustomHeaderInFunction_WithCgiMode_AndBody
2019/06/23 14:59:38 Forking fprocess.
2019/06/23 14:59:38 Wrote 362 Bytes - Duration: 0.002105 seconds
--- PASS: TestHandler_HasCustomHeaderInFunction_WithCgiMode_AndBody (0.00s)
=== RUN   TestHandler_HasHostHeaderWhenSet
2019/06/23 14:59:38 Forking fprocess.
2019/06/23 14:59:38 Wrote 363 Bytes - Duration: 0.000885 seconds
--- PASS: TestHandler_HasHostHeaderWhenSet (0.00s)
=== RUN   TestHandler_HostHeader_Empty_WhenNotSet
2019/06/23 14:59:38 Forking fprocess.
2019/06/23 14:59:38 Wrote 345 Bytes - Duration: 0.000926 seconds
--- PASS: TestHandler_HostHeader_Empty_WhenNotSet (0.00s)
=== RUN   TestHandler_StderrWritesToStderr_CombinedOutput_False
--- PASS: TestHandler_StderrWritesToStderr_CombinedOutput_False (0.00s)
=== RUN   TestHandler_StderrWritesToResponse_CombinedOutput_True
--- PASS: TestHandler_StderrWritesToResponse_CombinedOutput_True (0.00s)
=== RUN   TestHandler_DoesntHaveCustomHeaderInFunction_WithoutCgi_Mode
2019/06/23 14:59:38 Forking fprocess.
2019/06/23 14:59:38 Wrote 265 Bytes - Duration: 0.000952 seconds
--- PASS: TestHandler_DoesntHaveCustomHeaderInFunction_WithoutCgi_Mode (0.00s)
=== RUN   TestHandler_HasXDurationSecondsHeader
2019/06/23 14:59:38 Forking fprocess.
2019/06/23 14:59:38 Wrote 5 Bytes - Duration: 0.001072 seconds
--- PASS: TestHandler_HasXDurationSecondsHeader (0.00s)
=== RUN   TestHandler_RequestTimeoutFailsForExceededDuration
2019/06/23 14:59:38 Forking fprocess.
2019/06/23 14:59:38 Killing process: sleep 2
--- PASS: TestHandler_RequestTimeoutFailsForExceededDuration (0.10s)
=== RUN   TestHandler_StatusOKAllowed_ForWriteableVerbs
2019/06/23 14:59:38 Forking fprocess.
2019/06/23 14:59:38 Wrote 5 Bytes - Duration: 0.002449 seconds
2019/06/23 14:59:38 Forking fprocess.
2019/06/23 14:59:38 Wrote 5 Bytes - Duration: 0.002021 seconds
2019/06/23 14:59:38 Forking fprocess.
2019/06/23 14:59:38 Wrote 5 Bytes - Duration: 0.001452 seconds
--- PASS: TestHandler_StatusOKAllowed_ForWriteableVerbs (0.01s)
=== RUN   TestHandler_StatusMethodNotAllowed_ForUnknown
--- PASS: TestHandler_StatusMethodNotAllowed_ForUnknown (0.00s)
=== RUN   TestHandler_StatusOKForGETAndNoBody
2019/06/23 14:59:38 Forking fprocess.
2019/06/23 14:59:38 Wrote 29 Bytes - Duration: 0.001680 seconds
--- PASS: TestHandler_StatusOKForGETAndNoBody (0.00s)
=== RUN   TestHealthHandler_StatusOK_LockFilePresent
2019/06/23 14:59:38 Writing lock-file to: /tmp/.lock
--- PASS: TestHealthHandler_StatusOK_LockFilePresent (0.00s)
=== RUN   TestHealthHandler_StatusInternalServerError_LockFileNotPresent
2019/06/23 14:59:38 Removing lock-file : /tmp/.lock
--- PASS: TestHealthHandler_StatusInternalServerError_LockFileNotPresent (0.00s)
=== RUN   TestHealthHandler_SatusMethoNotAllowed_ForWriteableVerbs
--- PASS: TestHealthHandler_SatusMethoNotAllowed_ForWriteableVerbs (0.00s)
=== RUN   TestHandler_HasFullPathAndQueryInFunction_WithCgi_Mode
2019/06/23 14:59:38 Forking fprocess.
2019/06/23 14:59:38 Wrote 364 Bytes - Duration: 0.001167 seconds
--- PASS: TestHandler_HasFullPathAndQueryInFunction_WithCgi_Mode (0.00s)
PASS
ok      github.com/openfaas/faas/watchdog       0.133s
=== RUN   Test_Register_ProvidesBytes
2019/06/23 14:59:38 Metrics server. Port: 31111
--- PASS: Test_Register_ProvidesBytes (0.11s)
        metrics_test.go:32: cannot get metrics, or not ready: Get http://127.0.0.1:31111/metrics: dial tcp 127.0.0.1:31111: connect: connection refused
PASS
2019/06/23 14:59:38 metrics server shutdown
ok      github.com/openfaas/faas/watchdog/metrics       0.115s
?       github.com/openfaas/faas/watchdog/types [no test files]
Removing intermediate container 3c612ad65e3f
 ---> f50dafac9495
Step 17/17 : RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w         -X main.GitCommit=$GIT_COMMIT         -X main.Version=$VERSION"         -installsuffix cgo -o watchdog .     && GOARM=7 GOARCH=arm CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w         -X main.GitCommit=$GIT_COMMIT         -X main.Version=$VERSION"         -installsuffix cgo -o watchdog-armhf .     && GOARCH=arm64 CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w         -X main.GitCommit=$GIT_COMMIT         -X main.Version=$VERSION"         -installsuffix cgo -o watchdog-arm64 .     && GOOS=windows CGO_ENABLED=0 go build -a -ldflags "-s -w         -X main.GitCommit=$GIT_COMMIT         -X main.Version=$VERSION"         -installsuffix cgo -o watchdog.exe .
 ---> Running in 584271797d40
Removing intermediate container 584271797d40
 ---> dca73929c463
Successfully built dca73929c463
Successfully tagged openfaas/watchdog:build
Sending build context to Docker daemon  26.85MB
Step 1/4 : FROM openfaas/watchdog:build as build
 ---> dca73929c463
Step 2/4 : FROM scratch
 ---> 
Step 3/4 : ARG PLATFORM
 ---> Running in bdd27a7a2f13
Removing intermediate container bdd27a7a2f13
 ---> 00b29cc43d5d
Step 4/4 : COPY --from=build /go/src/github.com/openfaas/faas/watchdog/watchdog$PLATFORM ./fwatchdog
 ---> 83053b98fa2d
Successfully built 83053b98fa2d
Successfully tagged openfaas/classic-watchdog:latest-dev-armhf
Sending build context to Docker daemon  26.85MB
Step 1/4 : FROM openfaas/watchdog:build as build
 ---> dca73929c463
Step 2/4 : FROM scratch
 ---> 
Step 3/4 : ARG PLATFORM
 ---> Running in f7737a60b0ee
Removing intermediate container f7737a60b0ee
 ---> 2a22db094498
Step 4/4 : COPY --from=build /go/src/github.com/openfaas/faas/watchdog/watchdog$PLATFORM ./fwatchdog
 ---> 96b50d646dc1
Successfully built 96b50d646dc1
Successfully tagged openfaas/classic-watchdog:latest-dev-arm64
Sending build context to Docker daemon  26.85MB
Step 1/4 : FROM openfaas/watchdog:build as build
 ---> dca73929c463
Step 2/4 : FROM scratch
 ---> 
Step 3/4 : ARG PLATFORM
 ---> Running in ba79f0688165
Removing intermediate container ba79f0688165
 ---> 24085c5fbd41
Step 4/4 : COPY --from=build /go/src/github.com/openfaas/faas/watchdog/watchdog$PLATFORM ./fwatchdog
 ---> 1a62f269c753
Successfully built 1a62f269c753
Successfully tagged openfaas/classic-watchdog:latest-dev-windows
Sending build context to Docker daemon  26.85MB
Step 1/4 : FROM openfaas/watchdog:build as build
 ---> dca73929c463
Step 2/4 : FROM scratch
 ---> 
Step 3/4 : ARG PLATFORM
 ---> Running in bcf80859ebcf
Removing intermediate container bcf80859ebcf
 ---> 764d809bd69a
Step 4/4 : COPY --from=build /go/src/github.com/openfaas/faas/watchdog/watchdog$PLATFORM ./fwatchdog
 ---> b1589eac6b12
Successfully built b1589eac6b12
Successfully tagged openfaas/classic-watchdog:latest-dev-x86_64
b30189bd7ee84a6d43416c5988b56a6b56ee5e31c313592ea6a5df2e5500e4c5
buildoutput

Building openfaas/basic-auth-plugin:latest-dev
Sending build context to Docker daemon  44.03kB
Step 1/14 : FROM golang:1.10.4-alpine3.8 as build
 ---> bd36346540f3
Step 2/14 : RUN mkdir -p /go/src/handler
 ---> Using cache
 ---> 1e4aeaac85af
Step 3/14 : WORKDIR /go/src/handler
 ---> Using cache
 ---> 103d547eec2b
Step 4/14 : COPY . .
 ---> 4c8f7610d78d
Step 5/14 : RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"
 ---> Running in 60a369315310
Removing intermediate container 60a369315310
 ---> 2af0d53a95f8
Step 6/14 : RUN CGO_ENABLED=0 GOOS=linux     go build --ldflags "-s -w" -a -installsuffix cgo -o handler . &&     go test $(go list ./... | grep -v /vendor/) -cover
 ---> Running in 81af6eb3be62
ok      handler 0.007s  coverage: 43.3% of statements
Removing intermediate container 81af6eb3be62
 ---> 7a43262b0ed3
Step 7/14 : FROM alpine:3.9
 ---> 5cb3aa00f899
Step 8/14 : RUN addgroup -S app && adduser -S -g app app     && mkdir -p /home/app     && chown app /home/app
 ---> Using cache
 ---> ebc1a403135a
Step 9/14 : WORKDIR /home/app
 ---> Using cache
 ---> d25f36e5e3fe
Step 10/14 : COPY --from=build /go/src/handler/handler    .
 ---> Using cache
 ---> ead6b64b37d1
Step 11/14 : RUN chown -R app /home/app
 ---> Using cache
 ---> bda78aee1237
Step 12/14 : USER app
 ---> Using cache
 ---> 7ef047a8d832
Step 13/14 : WORKDIR /home/app
 ---> Using cache
 ---> 320b42e5b9ef
Step 14/14 : CMD ["./handler"]
 ---> Using cache
 ---> dda1d3a86d56
Successfully built dda1d3a86d56
Successfully tagged openfaas/basic-auth-plugin:latest-dev
```

### Running the `publish-arm.sh` on armhf

```
$ ./contrib/publish-arm.sh
...
Docker images
openfaas-incubator/openfaas-operator
 openfaas/openfaas-operator:0.9.7-armhf
openfaas-incubator/faas-idler
 openfaas/faas-idler:0.2.0-armhf
openfaas/faas
 openfaas/gateway:0.14.2-armhf
 openfaas/basic-auth-plugin:0.14.2-armhf
openfaas/faas-swarm
 openfaas/faas-swarm:0.6.2-armhf
openfaas/nats-queue-worker
 openfaas/queue-worker:0.7.2-armhf
openfaas/faas-netes
 openfaas/faas-netes:0.8.0-armhf
openfaas/faas-cli
 openfaas/faas-cli:0.8.14-armhf
```
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
