### PR TITLE
Move samples to non-root images and multi-stage Dockerfiles

### DIFF
--- a/sample-functions/AlpineFunction/Dockerfile
+++ b/sample-functions/AlpineFunction/Dockerfile
@@ -1,12 +1,15 @@
 FROM openfaas/classic-watchdog:0.14.4 as watchdog
 
-FROM alpine:3.9
+FROM alpine:3.10
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 # Populate example here
 # ENV fprocess="wc -l"
+
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+USER 1000
 
 HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
 CMD ["fwatchdog"]

--- a/sample-functions/AlpineFunction/Dockerfile.arm64
+++ b/sample-functions/AlpineFunction/Dockerfile.arm64
@@ -1,12 +1,15 @@
 FROM openfaas/classic-watchdog:0.14.4 as watchdog
 
-FROM alpine:3.9
+FROM alpine:3.10
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 # Populate example here
 # ENV fprocess="wc -l"
+
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+USER 1000
 
 HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
 CMD ["fwatchdog"]

--- a/sample-functions/AlpineFunction/Dockerfile.armhf
+++ b/sample-functions/AlpineFunction/Dockerfile.armhf
@@ -1,12 +1,15 @@
 FROM openfaas/classic-watchdog:0.14.4 as watchdog
 
-FROM alpine:3.9
+FROM alpine:3.10
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 # Populate example here
 # ENV fprocess="wc -l"
+
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+USER 1000
 
 HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
 CMD ["fwatchdog"]

--- a/sample-functions/BaseFunctions/R/Dockerfile
+++ b/sample-functions/BaseFunctions/R/Dockerfile
@@ -1,16 +1,19 @@
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
+
 FROM artemklevtsov/r-alpine:latest
 
-RUN apk --no-cache add curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 
-WORKDIR /root/
+WORKDIR /application/
 
 COPY handler.R .
 
 ENV fprocess="Rscript handler.R"
 
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+USER 1000
+
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 
 CMD ["fwatchdog"]
-

--- a/sample-functions/BaseFunctions/coffee/Dockerfile
+++ b/sample-functions/BaseFunctions/coffee/Dockerfile
@@ -1,10 +1,11 @@
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
+
 FROM node:6.9.1-alpine
 
-RUN apk --no-cache add curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 
-WORKDIR /root/
+WORKDIR /application/
 
 COPY package.json .
 
@@ -16,5 +17,7 @@ COPY handler.coffee .
 ENV fprocess="coffee handler.coffee"
 
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
+
+USER 1000
 
 CMD ["fwatchdog"]

--- a/sample-functions/BaseFunctions/dncore/Dockerfile
+++ b/sample-functions/BaseFunctions/dncore/Dockerfile
@@ -1,18 +1,21 @@
-FROM microsoft/dotnet:sdk
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
 
-RUN apt-get update && apt-get install -y curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as build
+
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
 
-WORKDIR /root/
+WORKDIR /application/
 COPY src src
-WORKDIR /root/src
+WORKDIR /application/src
 RUN dotnet restore
 RUN dotnet build
 
-ENV fprocess="dotnet ./bin/Debug/netcoreapp1.1/root.dll"
+FROM build as runner
+RUN groupadd -g 1000 -r faas && useradd -r -g faas -u 1000 faas -m
+USER 1000
+ENV fprocess="dotnet ./bin/Debug/netcoreapp2.1/root.dll"
 EXPOSE 8080
 CMD ["fwatchdog"]

--- a/sample-functions/BaseFunctions/dncore/README.md
+++ b/sample-functions/BaseFunctions/dncore/README.md
@@ -1,0 +1,9 @@
+# DnCore Example
+DotNet seems to have an issue where the following message can bee seen on STDOUT:
+```
+realpath(): Permission denied
+realpath(): Permission denied
+realpath(): Permission denied
+```
+
+This messages can be ignored and the issue can be followed at: https://github.com/dotnet/core-setup/issues/4038

--- a/sample-functions/BaseFunctions/dncore/src/root.csproj
+++ b/sample-functions/BaseFunctions/dncore/src/root.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/sample-functions/BaseFunctions/golang/Dockerfile
+++ b/sample-functions/BaseFunctions/golang/Dockerfile
@@ -1,3 +1,5 @@
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
+
 FROM golang:1.9.7-alpine
 
 MAINTAINER alexellis2@gmail.com
@@ -8,11 +10,13 @@ COPY . /go/src/github.com/openfaas/faas/sample-functions/golang
 
 RUN go install
 
-RUN apk --no-cache add curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 
 ENV fprocess "/go/bin/golang"
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 
-CMD [ "/usr/bin/fwatchdog"]
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+USER 1000
+
+CMD [ "fwatchdog"]

--- a/sample-functions/BaseFunctions/java/Dockerfile
+++ b/sample-functions/BaseFunctions/java/Dockerfile
@@ -1,15 +1,19 @@
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
+
 FROM openjdk:8u121-jdk-alpine
 
-RUN apk --no-cache add curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 
-WORKDIR /root/
+WORKDIR /application/
 
 COPY Handler.java .
 RUN javac Handler.java
 
 ENV fprocess="java Handler"
+
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+USER 1000
 
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 

--- a/sample-functions/BaseFunctions/node/Dockerfile
+++ b/sample-functions/BaseFunctions/node/Dockerfile
@@ -1,14 +1,18 @@
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
+
 FROM node:6.9.1-alpine
 
-RUN apk --no-cache add curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
-WORKDIR /root/
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+
+WORKDIR /application/
 
 COPY package.json .
 
 RUN npm i
 COPY handler.js .
+
+USER 1000
 
 ENV fprocess="node handler.js"
 

--- a/sample-functions/BaseFunctions/python/Dockerfile
+++ b/sample-functions/BaseFunctions/python/Dockerfile
@@ -1,14 +1,18 @@
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
+
 FROM python:2.7-alpine
 
-RUN apk --no-cache add curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 
-WORKDIR /root/
+WORKDIR /application/
 
 COPY handler.py .
 
 ENV fprocess="python handler.py"
+
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+USER 1000
 
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 

--- a/sample-functions/CHelloWorld/src/Dockerfile
+++ b/sample-functions/CHelloWorld/src/Dockerfile
@@ -1,10 +1,12 @@
-FROM alpine:3.8 as builder
-RUN apk add --no-cache curl \
-    && curl -SL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog \
-    && apk --no-cache del curl
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
 
-WORKDIR /root/
+FROM alpine:3.10 as builder
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+
+WORKDIR /application/
+
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
 
 RUN apk add --no-cache gcc \
     musl-dev
@@ -18,11 +20,13 @@ FROM scratch
 
 COPY --from=builder /main               /
 COPY --from=builder /usr/bin/fwatchdog  /
-COPY --from=builder /tmp /tmp
 
 ENV fprocess="/main"
+ENV suppress_lock=true
 
-HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
+COPY --from=builder /etc/passwd /etc/passwd
 
-CMD ["/fwatchdog"]
+USER 1000
+
+CMD ["fwatchdog"]
 

--- a/sample-functions/CaptainsIntent/Dockerfile
+++ b/sample-functions/CaptainsIntent/Dockerfile
@@ -1,9 +1,12 @@
-FROM alpine:3.8
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
+
+FROM alpine:3.10
 RUN apk --update add nodejs nodejs-npm
 
-RUN apk --no-cache add curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+
+WORKDIR /application/
 
 COPY package.json   .
 COPY handler.js     .
@@ -12,4 +15,7 @@ COPY sample.json    .
 
 RUN npm i
 ENV fprocess="node handler.js"
+
+USER 1000
+
 CMD ["fwatchdog"]

--- a/sample-functions/ChangeColorIntent/Dockerfile
+++ b/sample-functions/ChangeColorIntent/Dockerfile
@@ -1,9 +1,12 @@
-FROM alpine:3.8
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
+
+FROM alpine:3.10
 RUN apk --update add nodejs nodejs-npm
 
-RUN apk --no-cache add curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+
+WORKDIR /application/
 
 COPY package.json           .
 RUN npm i
@@ -11,6 +14,7 @@ COPY handler.js             .
 COPY sendColor.js           .
 COPY sample_response.json   .
 
+USER 1000
 
 ENV fprocess="node handler.js"
 CMD ["fwatchdog"]

--- a/sample-functions/DockerHubStats/Dockerfile
+++ b/sample-functions/DockerHubStats/Dockerfile
@@ -1,26 +1,26 @@
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
+
 FROM golang:1.9.7-alpine as builder
 
 MAINTAINER alex@openfaas.com
 ENTRYPOINT []
 
-RUN apk --no-cache add make curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
-
 WORKDIR /go/src/github.com/openfaas/faas/sample-functions/DockerHubStats
-
 COPY . /go/src/github.com/openfaas/faas/sample-functions/DockerHubStats
+RUN set -ex && apk add make && make install
 
-RUN make install
-
-FROM alpine:3.8
+FROM alpine:3.10
 
 # Needed to reach the hub
 RUN apk --no-cache add ca-certificates 
 
-COPY --from=builder /usr/bin/fwatchdog  /usr/bin/fwatchdog
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 COPY --from=builder /go/bin/DockerHubStats  /usr/bin/DockerHubStats
 ENV fprocess "/usr/bin/DockerHubStats"
+
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+USER 1000
 
 HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
 CMD ["/usr/bin/fwatchdog"]

--- a/sample-functions/DockerHubStats/Dockerfile.armhf
+++ b/sample-functions/DockerHubStats/Dockerfile.armhf
@@ -13,7 +13,7 @@ COPY . /go/src/github.com/openfaas/faas/sample-functions/DockerHubStats
 
 RUN make install
 
-FROM alpine:3.8
+FROM alpine:3.10
 
 # Needed to reach the hub
 RUN apk --no-cache add ca-certificates 

--- a/sample-functions/HostnameIntent/Dockerfile
+++ b/sample-functions/HostnameIntent/Dockerfile
@@ -1,9 +1,5 @@
-FROM alpine:3.8
+FROM functions/alpine:latest
 RUN apk --update add nodejs nodejs-npm
-
-RUN apk --no-cache add curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
 
 COPY package.json   .
 COPY handler.js     .

--- a/sample-functions/MarkdownRender/Dockerfile
+++ b/sample-functions/MarkdownRender/Dockerfile
@@ -3,10 +3,6 @@ FROM golang:1.9.7-alpine as builder
 MAINTAINER alex@openfaas.com
 ENTRYPOINT []
 
-RUN apk --no-cache add make curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
-
 WORKDIR /go/src/github.com/openfaas/faas/sample-functions/MarkdownRender
 
 COPY handler.go .
@@ -14,12 +10,11 @@ COPY vendor vendor
 
 RUN go install
 
-FROM alpine:3.8
+FROM functions/alpine:latest
 
 # Needed to reach the hub
 RUN apk --no-cache add ca-certificates 
 
-COPY --from=builder /usr/bin/fwatchdog  /usr/bin/fwatchdog
 COPY --from=builder /go/bin/MarkdownRender  /usr/bin/MarkdownRender
 ENV fprocess "/usr/bin/MarkdownRender"
 

--- a/sample-functions/NodeInfo/Dockerfile
+++ b/sample-functions/NodeInfo/Dockerfile
@@ -1,9 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
-
-FROM alpine:3.9
-
-COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
-RUN chmod +x /usr/bin/fwatchdog
+FROM functions/alpine:latest
 
 RUN apk --update add nodejs nodejs-npm
 

--- a/sample-functions/NodeInfo/Dockerfile.arm64
+++ b/sample-functions/NodeInfo/Dockerfile.arm64
@@ -1,9 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
-
-FROM alpine:3.9
-
-COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
-RUN chmod +x /usr/bin/fwatchdog
+FROM functions/alpine:latest
 
 RUN apk --update add nodejs nodejs-npm
 

--- a/sample-functions/NodeInfo/Dockerfile.armhf
+++ b/sample-functions/NodeInfo/Dockerfile.armhf
@@ -1,9 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
-
-FROM alpine:3.9
-
-COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
-RUN chmod +x /usr/bin/fwatchdog
+FROM functions/alpine:latest
 
 RUN apk --update add nodejs nodejs-npm
 

--- a/sample-functions/Phantomjs/Dockerfile
+++ b/sample-functions/Phantomjs/Dockerfile
@@ -1,11 +1,14 @@
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
+
 FROM alexellis2/phantomjs-docker:latest
 
-RUN apt-get update && apt-get install -y curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 
 ENV fprocess="phantomjs /dev/stdin"
+
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+USER 1000
 
 HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
 CMD ["fwatchdog"]

--- a/sample-functions/ResizeImageMagick/Dockerfile
+++ b/sample-functions/ResizeImageMagick/Dockerfile
@@ -1,10 +1,14 @@
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
+
 FROM v4tech/imagemagick
 
-RUN apk --no-cache add curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 
 ENV fprocess "convert - -resize 50% fd:1"
+
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+USER 1000
 
 EXPOSE 8080
 

--- a/sample-functions/ResizeImageMagick/Dockerfile.armhf
+++ b/sample-functions/ResizeImageMagick/Dockerfile.armhf
@@ -1,12 +1,16 @@
-FROM arm32v6/alpine:3.8
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
+
+FROM arm32v6/alpine:3.10
 
 RUN apk --no-cache add imagemagick
 
-RUN apk --no-cache add curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog-armhf > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 
 ENV fprocess "convert - -resize 50% fd:1"
+
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+USER 1000
 
 EXPOSE 8080
 

--- a/sample-functions/SentimentAnalysis/Dockerfile
+++ b/sample-functions/SentimentAnalysis/Dockerfile
@@ -1,18 +1,18 @@
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
+
 FROM python:2.7-alpine
 
 RUN pip install textblob && \
     python -m textblob.download_corpora
 
-RUN apk --no-cache add curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 
-RUN addgroup -S app \
-    && adduser -S -g app app
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+USER 1000
 
 WORKDIR /home/app
 
-USER app
 COPY requirements.txt   .
 RUN pip install -r requirements.txt
 

--- a/sample-functions/SentimentAnalysis/Dockerfile.armhf
+++ b/sample-functions/SentimentAnalysis/Dockerfile.armhf
@@ -1,19 +1,28 @@
+FROM openfaas/classic-watchdog:0.14.4 as watchdog
+
 FROM arm32v7/python:2.7-slim
 
 RUN pip install textblob && \
     python -m textblob.download_corpora
 
-RUN apt-get update && apt-get install -y curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog-armhf > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 
-WORKDIR /root/
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+USER 1000
+
+WORKDIR /home/app
+
+COPY requirements.txt   .
+RUN pip install -r requirements.txt
+
+RUN python -m textblob.download_corpora
 
 COPY handler.py .
-
 ENV fprocess="python handler.py"
 
-HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
+HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
 
 CMD ["fwatchdog"]
+
+

--- a/sample-functions/WebhookStash/Dockerfile
+++ b/sample-functions/WebhookStash/Dockerfile
@@ -3,10 +3,6 @@ FROM golang:1.9.7-alpine as builder
 MAINTAINER alex@openfaas.com
 ENTRYPOINT []
 
-RUN apk --no-cache add make curl \
-    && curl -sL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog
-
 WORKDIR /go/src/github.com/openfaas/faas/sample-functions/WebhookStash
 
 COPY handler.go .
@@ -14,12 +10,11 @@ COPY handler.go .
 
 RUN go install
 
-FROM alpine:3.8
+FROM functions/alpine:latest
 
 # Needed to reach the hub
 RUN apk --no-cache add ca-certificates 
 
-COPY --from=builder /usr/bin/fwatchdog  /usr/bin/fwatchdog
 COPY --from=builder /go/bin/WebhookStash  /usr/bin/WebhookStash
 ENV fprocess "/usr/bin/WebhookStash"
 

--- a/sample-functions/figlet/Dockerfile
+++ b/sample-functions/figlet/Dockerfile
@@ -1,15 +1,8 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
-
-FROM alpine:3.9
-
-COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
-RUN chmod +x /usr/bin/fwatchdog
+FROM functions/alpine:latest
 
 RUN apk add --no-cache figlet
 
-# Populate example here
 ENV fprocess="figlet"
 
 HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
 CMD ["fwatchdog"]
-

--- a/sample-functions/figlet/Dockerfile.armhf
+++ b/sample-functions/figlet/Dockerfile.armhf
@@ -1,15 +1,8 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
-
-FROM alpine:3.9
-
-COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
-RUN chmod +x /usr/bin/fwatchdog
+FROM functions/alpine:latest
 
 RUN apk add --no-cache figlet
 
-# Populate example here
 ENV fprocess="figlet"
 
 HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
 CMD ["fwatchdog"]
-

--- a/sample-functions/gif-maker/Dockerfile
+++ b/sample-functions/gif-maker/Dockerfile
@@ -1,9 +1,6 @@
-FROM alpine:3.8
+FROM functions/alpine:latest
 
-RUN apk --no-cache add ffmpeg gifsicle curl \
-    && curl -LS https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog \
-    && apk del curl
+RUN apk add ffmpeg gifsicle
 WORKDIR /root/
 COPY entry.sh   .
 ENV fprocess="./entry.sh"


### PR DESCRIPTION
## Description
Improving docker images to use a non-root user and standardising the fwatchdog installation using multistage Dockerfiles

## Motivation and Context
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label
https://github.com/openfaas/faas/issues/1167

## How Has This Been Tested?
- Build the image
- Start fwatchdog process
- HTTP request to 8080 port

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
