### PR TITLE
Collapse Dockerfile.armhf into Dockerfile

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,8 +1,12 @@
-FROM golang:1.10.4 as build
+FROM golang:1.10 as build
+
 ARG GIT_COMMIT_SHA
 ARG GIT_COMMIT_MESSAGE
 ARG VERSION='dev'
-ARG ARCH
+ARG ARCH="x86_64"
+ARG CGO_ENABLED=0
+ARG GOOS=linux
+ARG GOARM
 
 RUN curl -sLSf \
   https://raw.githubusercontent.com/teamserverless/license-check/master/get.sh | sh \
@@ -25,17 +29,19 @@ COPY scaling        scaling
 COPY server.go      .
 
 # Run a gofmt and exclude all vendored code.
-RUN license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Project" "OpenFaaS Authors" "OpenFaaS Author(s)" \
+RUN license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Authors" "OpenFaaS Author(s)" \
     && test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))" \
-    && go test $(go list ./... | grep -v integration | grep -v /vendor/ | grep -v /template/) -cover \
-    && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w \
+    && CGO_ENABLED=${CGO_ENABLED} go test $(go list ./... | grep -v integration | grep -v /vendor/ | grep -v /template/) -cover \
+    && GOARM=${GOARM} CGO_ENABLED=${CGO_ENABLED} GOOS=linux go build --ldflags "-s -w \
     -X github.com/openfaas/faas/gateway/version.GitCommitSHA=${GIT_COMMIT_SHA}\
     -X \"github.com/openfaas/faas/gateway/version.GitCommitMessage=${GIT_COMMIT_MESSAGE}\"\
     -X \"github.com/openfaas/faas/gateway/version.Version=${VERSION}\" \
     -X github.com/openfaas/faas/gateway/types.Arch=${ARCH}"\
     -a -installsuffix cgo -o gateway .
 
-FROM alpine:3.9
+FROM alpine:3.10
+
+ARG ARCH="x86_64"
 
 LABEL org.label-schema.license="MIT" \
     org.label-schema.vcs-url="https://github.com/openfaas/faas" \
@@ -57,9 +63,12 @@ ENV https_proxy     ""
 
 COPY --from=build /go/src/github.com/openfaas/faas/gateway/gateway    .
 COPY assets     assets
+RUN sed -ie s/x86_64/${ARCH}/g assets/script/funcstore.js && \
+  rm assets/script/funcstore.jse
 
 RUN chown -R app:app ./
 
 USER app
 
 CMD ["./gateway"]
+

--- a/gateway/Makefile
+++ b/gateway/Makefile
@@ -1,6 +1,8 @@
-.PHONY: all build
+.PHONY: all build push
 TAG?=latest
 
 all:	build
 build:
 	./build.sh ${TAG}
+push:
+	./push.sh ${TAG}

--- a/gateway/build.sh
+++ b/gateway/build.sh
@@ -5,15 +5,18 @@ export dockerfile="Dockerfile"
 export arch=$(uname -m)
 
 export eTAG="latest-dev"
+export GOARM=""
 
 if [ "$arch" = "armv7l" ] ; then
-   dockerfile="Dockerfile.armhf"
+   dockerfile="Dockerfile"
    eTAG="latest-armhf-dev"
    arch="armhf"
+   GOARM="7"
 elif [ "$arch" = "aarch64" ] ; then
    arch="arm64"
    dockerfile="Dockerfile.arm64"
    eTAG="latest-arm64-dev"
+   GOARM="8"
 fi
 
 echo "$1"
@@ -28,14 +31,15 @@ fi
 
 NS=openfaas
 
-echo Building $NS/gateway:$eTAG
+echo "Building $NS/gateway:$eTAG with $dockerfile for $arch"
 
 GIT_COMMIT_MESSAGE=$(git log -1 --pretty=%B 2>&1 | head -n 1)
 GIT_COMMIT_SHA=$(git rev-list -1 HEAD)
 VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///' || echo dev)
 
 docker build --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy \
-  --build-arg GIT_COMMIT_MESSAGE="$GIT_COMMIT_MESSAGE" --build-arg GIT_COMMIT_SHA=$GIT_COMMIT_SHA \
-  --build-arg VERSION=${VERSION:-dev} \
-  --build-arg ARCH=$arch \
+  --build-arg GIT_COMMIT_MESSAGE="${GIT_COMMIT_MESSAGE}" --build-arg GIT_COMMIT_SHA="${GIT_COMMIT_SHA}" \
+  --build-arg VERSION="${VERSION:-dev}" \
+  --build-arg GOARM="${GOARM}" \
+  --build-arg ARCH="${arch}" \
   -t $NS/gateway:$eTAG . -f $dockerfile --no-cache

--- a/gateway/build.sh
+++ b/gateway/build.sh
@@ -14,9 +14,8 @@ if [ "$arch" = "armv7l" ] ; then
    GOARM="7"
 elif [ "$arch" = "aarch64" ] ; then
    arch="arm64"
-   dockerfile="Dockerfile.arm64"
+   dockerfile="Dockerfile"
    eTAG="latest-arm64-dev"
-   GOARM="8"
 fi
 
 echo "$1"


### PR DESCRIPTION

Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Collapse Dockerfile.armhf into Dockerfile

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to #1257 

CGO_ENABLED and GOARM etc are now passed as ARGs via build.sh.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This change which has been tested on armhf and x86_64 removes
the need for a separate Dockerfile for armhf.

The store values showed as expected, after some initial issues
I found, where the `ARG` has to be redeclared for multi-stage builds.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Refactoring

This can be merged, and I'll remove Dockerfile.armhf after testing the publish-arm script.