### PR TITLE
Update Governance and Team structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,7 +232,7 @@ The Members Team are expected to:
 
 This group is intended to be an active team that shares the load and collaborates together. This means engaging in topics on Slack, encouraging other teammates, sharing ideas, helping the users and raising issues with the Core Team.
 
-The Members Team will notify the Members Team of any leave of a week or more and set a status in Slack of "away".
+The Members Team will notify their team in the *members* channel about any planned leave of a week or more and set a status in Slack of "away".
 
 #### Changing teams
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,9 +239,9 @@ If you can no-longer commit to being part of a team, then you may move to Commun
 
 #### Stepping-down
 
-From the [Ubuntu community guidelines](https://ubuntu.com/community/code-of-conduct):
-
 > When somebody leaves or disengages from the project, we ask that they do so in a way that minimises disruption to the project. They should tell [*The Project Lead*, that] they are leaving and take the proper steps to ensure that others can pick up where they left off.
+
+Quoted from the [Ubuntu community guidelines](https://ubuntu.com/community/code-of-conduct).
 
 #### How do I get access to Derek?
 
@@ -260,27 +260,33 @@ General format:
 - Demos of features/new work from community
 - Q&A
 
+If you would like invites, sign-up to Slack and pick "Yes" to Community Events and Updates.
+
 ## Branding guidelines
 
 For press, branding, logos and marks see the [OpenFaaS media repository](https://github.com/openfaas/media).
 
 ## Community
 
-This project is written in Golang but many of the community contributions so far have been through blogging, speaking engagements, helping to test and drive the backlog of FaaS. If you'd like to help in any way then that would be more than welcome whatever your level of experience.
+This project is written in Golang but many of the community contributions so far have been through blogging, speaking engagements, helping to test and drive the backlog of OpenFaaS. If you'd like to help in any way then that would be more than welcome whatever your level of experience.
 
 ### Community file
 
-The [community.md](https://github.com/openfaas/faas/blob/master/community.md) file highlights blogs, talks and code repos with example FaaS functions and usages. Please send a Pull Request if you are doing something cool with FaaS.
-
-### Roadmap
-
-Checkout the [roadmap](https://github.com/openfaas/faas/blob/master/ROADMAP.md) and [open issues](https://github.com/openfaas/faas/issues).
+The [community.md](https://github.com/openfaas/faas/blob/master/community.md) file highlights blogs, talks and code repos with example FaaS functions and usages. Please send a Pull Request if you are doing something cool with OpenFaaS.
 
 ### Slack
 
-There is an Slack community which you are welcome to join to discuss FaaS, IoT and Raspberry Pi projects. Ping [Alex Ellis](https://github.com/alexellis) with your email address so that an invite can be sent out.
+There is an Slack community which you are welcome to join to discuss Kubernetes, Serverless, FaaS, IoT, and Raspberry Pi projects.
 
-Please send in a short one-line message about yourself to alex@openfaas.com so that we can give you a warm welcome and help you get started.
+[Join Slack here](https://docs.openfaas.com/support)
+
+### Roadmap
+
+* See the [2019 Project Update](https://www.openfaas.com/blog/project-update/)
+
+* Browse open issues in [openfaas/faas](https://github.com/openfaas/faas/issues)
+
+* Sign-up for the [2019 Trello board](http://bit.ly/2LGl6nd)
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ Credentials for the `openfaas` and/or `functions` Docker Hub and quay.io account
 
 OpenFaaS is an independent open-source project which was created by the Project Lead Alex Ellis in 2016. OpenFaaS is now being built by Alex, a number of volunteer teams, and a wider community of open-source developers.
 
-OpenFaaS Ltd (company no. 11076587) sponsors the development and maintenance of OpenFaaS. OpenFaaS Ltd provides professional services, consultation and support.
+OpenFaaS Ltd (company no. 11076587) sponsors the development and maintenance of OpenFaaS. OpenFaaS Ltd provides professional services, consultation and support. Email: [sales@openfaas.com](mailto:sales@openfaas.com) to make a query.
 
 OpenFaaS &reg; is a registered trademark in England and Wales.
 
@@ -164,10 +164,9 @@ In the OpenFaaS community there are four levels of structure or maintainership:
 * Core Team (GitHub org)
 * Members Team (GitHub org)
 * Those with Derek access
+* The rest of the community.
 
-The rest of the community.
-
-#### Who are the Core Team?
+#### Core Team
 
 The Core Team includes:
 
@@ -180,7 +179,7 @@ The Core Team includes:
 
 The Core Team have the ear of the Project Lead. They help with strategy, project maintenance, community management, and make a regular commitment of time to the project on a weekly basis. The Core Team will usually be responsible for, or be a subject-matter-expert (SME) for a sub-system of OpenFaaS. Core Team may be granted write (push) access to one or more sub-systems.
 
-The Core Team gain access to a private *core* channel and are expected to participate on a regular basis.
+The Core Team gain access to a private *core* channel and are required to participate on a regular basis.
 
 The Core Team have the same expectations and perks of the Membership Team, in addition will need to keep in close contact with the rest of the Core Team and the Project Lead.
 
@@ -243,7 +242,7 @@ If you can no-longer commit to being part of a team, then you may move to Commun
 
 Quoted from the [Ubuntu community guidelines](https://ubuntu.com/community/code-of-conduct).
 
-#### How do I get access to Derek?
+#### Access to Derek
 
 If you have been added to the `.DEREK.yml` file in the root of an OpenFaaS repository then you can help us manage the community and contributions by issuing comments on Issues and Pull Requests. See [Derek](https://github.com/alexellis/derek) for available commands.
 
@@ -276,7 +275,7 @@ The [community.md](https://github.com/openfaas/faas/blob/master/community.md) fi
 
 ### Slack
 
-There is an Slack community which you are welcome to join to discuss Kubernetes, Serverless, FaaS, IoT, and Raspberry Pi projects.
+There is an Slack community which you are welcome to join to discuss OpenFaaS, OpenFaaS Cloud, Kubernetes, Serverless, FaaS, IoT, and ARM / Raspberry Pi.
 
 [Join Slack here](https://docs.openfaas.com/support)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,12 +53,7 @@ Once your proposal receives a `design/approved` label you may go ahead and start
 
 If you are proposing a new tool or service please do due diligence. Does this tool already exist in a 3rd party project or library? Can we reuse it? For example: a timer / CRON-type scheduler for invoking functions is a well-solved problem, do we need to reinvent the wheel?
 
-<!-- 
-#### What happens if you ignore the process?
-
-If you raise a PR without following the process, it could be closed and marked as invalid. You may have also made an honest mistake or you may have have chosen not to follow the contribution guidelines.
-
-This is not the end of the discussion, but it's not a great first impression for the community either. At that point, you should request comment on your proposal issue from the *Project Lead* and *Core Team*. If a label of `design/approved` is applied to your proposal, it means that you can go ahead and start on your PR/implementation. -->
+Every effort will be made to work with contributors who do not follow the process. Your PR may be closed or marked as `invalid` if it is left inactive, or the proposal cannot move into a `design/approved` status.
 
 #### Paperwork for Pull Requests
 
@@ -239,7 +234,7 @@ This group is intended to be an active team that shares the load and collaborate
 
 The Members Team will notify the Members Team of any leave of a week or more and set a status in Slack of "away".
 
-#### Changing team
+#### Changing teams
 
 Every contributor to OpenFaaS is a volunteer, including the *Project Lead* and nobody is paid to work on OpenFaaS.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ If you are proposing a new tool or service please do due diligence. Does this to
 
 If you raise a PR without following the process, it will be closed immediately and marked as invalid. You may have also made an honest mistake or you may have have chosen not to follow the contribution guidelines.
 
-This is not the end of the discussion, but it's not a great first impression for the community either. At that point, you should request comment on your proposal issue from the project lead and core contributors. If a label of `design/approved` is applied to your proposal, it means that you can go ahead and start on your PR/implementation.
+This is not the end of the discussion, but it's not a great first impression for the community either. At that point, you should request comment on your proposal issue from the *Project Lead* and *Core Team*. If a label of `design/approved` is applied to your proposal, it means that you can go ahead and start on your PR/implementation.
 
 #### Paperwork for Pull Requests
 
@@ -149,17 +149,27 @@ Releases are cut with `git` tags and a successful Travis build results in new bi
 
 Credentials for the `openfaas` and/or `functions` Docker Hub and quay.io accounts are coordinated by the project lead using.
 
+## Governance
+
+OpenFaaS is an independent open-source project which was created by the Project Lead Alex Ellis in 2016. OpenFaaS is now being built by Alex, a number of volunteer teams, and a wider community of open-source developers.
+
+OpenFaaS Ltd (company no. 11076587) sponsors the development and maintenance of OpenFaaS. OpenFaaS Ltd provides professional services, consultation and support.
+
+OpenFaaS &reg; is a registered trademark in England and Wales.
+
 ### How do I become a maintainer?
 
-In the OpenFaaS community there are three levels of maintainership:
+In the OpenFaaS community there are four levels of structure or maintainership:
 
-* Core Contributors
-* GitHub Organisation Members
+* Core Team (GitHub org)
+* Members Team (GitHub org)
 * Those with Derek access
 
-#### Who are the Core Contributors?
+The rest of the community.
 
-The Core Contributor group includes:
+#### Who are the Core Team?
+
+The Core Team includes:
 
 - Alex Ellis (@alexellis)
 - Richard Gee (@rgee0)
@@ -168,30 +178,70 @@ The Core Contributor group includes:
 - Burton Rheutan (@burtonr)
 - Ed Wilde (@ewilde)
 
-The Core Contributors have the ear of the project lead and help with strategy, project maintenance, community management and make a regular commitment of time to the project. Core contributors will usually look after or be a subject-matter-expert (SME) for a sub-system of OpenFaaS. Core contributors may be granted write (push) access to one or more sub-systems.
+The Core Team have the ear of the Project Lead. They help with strategy, project maintenance, community management, and make a regular commitment of time to the project on a weekly basis. The Core Team will usually be responsible for, or be a subject-matter-expert (SME) for a sub-system of OpenFaaS. Core Team may be granted write (push) access to one or more sub-systems.
 
-Core Contributors attend all project meetings and calls.
+The Core Team gain access to a private *core* channel and are expected to participate on a regular basis.
 
-#### GitHub Organisation Members
+The Core Team have the same expectations and perks of the Membership Team, in addition will need to keep in close contact with the rest of the Core Team and the Project Lead.
 
-GitHub Organisation Members are well-known contributors with a track record of:
+* Core Team are expected to attend 1:1 Zoom calls with the Project Lead up to once per month
+* Core Team members will notify the Project Lead and Core Team of any leave of a week or more and set a status in Slack of "away".
 
-* Fixing, testing and triaging issues
-* Joining contributor meetings and supporting new contributors
-* Testing and reviewing pull requests
-* Offering other project support, feedback and being available to help
+Core Team attend all project meetings and calls.
 
-Varying levels of write access are made available via the project bot [Derek](https://github.com/alexellis/derek) to help regular contributors transition to GitHub Organisation Membership. Members gain access to a private Slack channel and are also featured on the Team page of the OpenFaaS website.
+#### Members Team
 
-GitHub Organisation Members are expected to:
+The Members Team are contributors who are well-known to the community with a track record of:
 
+* fixing, testing and triaging issues and PRs
+* offering support to the project
+* providing feedback and being available to help where needed
+* testing and reviewing pull requests
+* joining contributor meetings and supporting new contributors
+
+> Note: An essential skill for being in a team is communication. If you cannot communicate with your team on a regular basis, then membership may not be for you and you are welcome to contribute as community.
+
+Varying levels of write access are made available via the project bot [Derek](https://github.com/alexellis/derek) to help regular contributors transition to the Members Team.
+
+Members Team Perks:
+* access to a private Slack channel
+* profile posted on the Team page of the OpenFaaS website
+* membership of the GitHub organisations openfaas/openfaas-incubator
+
+Upon request and subject to availability:
+* 1:1 coaching & mentorship
+* help with speaking opportunities and CfP submissions
+* help with CV, resume and LinkedIn profile
+* review, and promotion of blogs and tutorials on social media
+
+The Members Team are expected to:
+
+* participate in the members channel and engage with the topics
 * participate in community Zoom calls (when possible within your timezone)
 * make regular contributions to the project codebase
-* participate in the members channel and engage with the topics
 * take an active role in the public channels: #contributors and #openfaas
 * comment on and engage with project proposals
+* attend occasional 1:1 meetings with members of the Core Team or the Project Lead
 
-This group is intended to be an active team that shares the load and collaborates together. Sometimes finding time to participate can be challenging when balanced with other commitments so if you are likely to be inactive or away for several weeks, then please contact the project lead.
+This group is intended to be an active team that shares the load and collaborates together. This means engaging in topics on Slack, encouraging other teammates, sharing ideas, helping the users and raising issues with the Core Team.
+
+The Members Team will notify the Members Team of any leave of a week or more and set a status in Slack of "away".
+
+#### Changing team
+
+Every contributor to OpenFaaS is a volunteer, including the *Project Lead* and nobody is paid to work on OpenFaaS.
+
+Motivations and life-circumstances can change over time. If this is expected to be a short-term change, then speak to the *Project Lead* about a sabbatical arrangement with perks and membership retained for that time.
+
+You may move from the Core Team to the Members Team. Please notify the *Project Lead*.
+
+If you can no-longer commit to being part of a team, then you may move to Community Contributor status and retain your access to Derek for as long as it is useful to you.
+
+#### Stepping-down
+
+From the [Ubuntu community guidelines](https://ubuntu.com/community/code-of-conduct):
+
+> When somebody leaves or disengages from the project, we ask that they do so in a way that minimises disruption to the project. They should tell [*The Project Lead*, that] they are leaving and take the proper steps to ensure that others can pick up where they left off.
 
 #### How do I get access to Derek?
 
@@ -209,10 +259,6 @@ General format:
 - Round-table intros/updates
 - Demos of features/new work from community
 - Q&A
-
-## Governance
-
-OpenFaaS is an independent project created by Alex Ellis in 2016. OpenFaaS is led by Alex and is being built in the open by a growing community of contributors.
 
 ## Branding guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ Releases are made by the *Project Lead* on a regular basis and when deemed neces
 
 Releases are cut with `git` tags and a successful Travis build results in new binary artifacts and Docker images being published to the Docker Hub and Quay.io. See the "Build" badge on each GitHub README file for more.
 
-Credentials for the `openfaas` and/or `functions` Docker Hub and quay.io accounts are coordinated by the project lead using.
+How are credentials managed for quay.io and the Docker Hub? These credentials are maintained by the *Project Lead*.
 
 ## Governance
 
@@ -155,7 +155,7 @@ OpenFaaS &reg; is a registered trademark in England and Wales.
 
 #### Project Lead
 
-Responsibility for the project starts with the *Project Lead**, who delegates specific responsibilities and the corresponding authority to the Core and Members team.
+Responsibility for the project starts with the *Project Lead*, who delegates specific responsibilities and the corresponding authority to the Core and Members team.
 
 Some duties include:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,7 @@ The Core Team have the same expectations and perks of the Membership Team, in ad
 * Core Team are expected to attend 1:1 Zoom calls with the Project Lead up to once per month
 * Core Team members will notify the Project Lead and Core Team of any leave of a week or more and set a status in Slack of "away".
 
-Core Team attend all project meetings and calls.
+Core Team attend all project meetings and calls. Allowances will be made for timezones and other commitments.
 
 #### Members Team
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,11 +53,12 @@ Once your proposal receives a `design/approved` label you may go ahead and start
 
 If you are proposing a new tool or service please do due diligence. Does this tool already exist in a 3rd party project or library? Can we reuse it? For example: a timer / CRON-type scheduler for invoking functions is a well-solved problem, do we need to reinvent the wheel?
 
+<!-- 
 #### What happens if you ignore the process?
 
-If you raise a PR without following the process, it will be closed immediately and marked as invalid. You may have also made an honest mistake or you may have have chosen not to follow the contribution guidelines.
+If you raise a PR without following the process, it could be closed and marked as invalid. You may have also made an honest mistake or you may have have chosen not to follow the contribution guidelines.
 
-This is not the end of the discussion, but it's not a great first impression for the community either. At that point, you should request comment on your proposal issue from the *Project Lead* and *Core Team*. If a label of `design/approved` is applied to your proposal, it means that you can go ahead and start on your PR/implementation.
+This is not the end of the discussion, but it's not a great first impression for the community either. At that point, you should request comment on your proposal issue from the *Project Lead* and *Core Team*. If a label of `design/approved` is applied to your proposal, it means that you can go ahead and start on your PR/implementation. -->
 
 #### Paperwork for Pull Requests
 
@@ -143,7 +144,7 @@ The chosen tool for vendoring code in the project is [dep](https://github.com/go
 
 ### How are releases made?
 
-Releases are made by the project lead when deemed necessary. If you want to request a new release then mention this on your PR or Issue.
+Releases are made by the *Project Lead* on a regular basis and when deemed necessary. If you want to request a new release then mention this on your PR or Issue.
 
 Releases are cut with `git` tags and a successful Travis build results in new binary artifacts and Docker images being published to the Docker Hub and Quay.io. See the "Build" badge on each GitHub README file for more.
 
@@ -156,6 +157,18 @@ OpenFaaS is an independent open-source project which was created by the Project 
 OpenFaaS Ltd (company no. 11076587) sponsors the development and maintenance of OpenFaaS. OpenFaaS Ltd provides professional services, consultation and support. Email: [sales@openfaas.com](mailto:sales@openfaas.com) to make a query.
 
 OpenFaaS &reg; is a registered trademark in England and Wales.
+
+#### Project Lead
+
+Responsibility for the project starts with the *Project Lead**, who delegates specific responsibilities and the corresponding authority to the Core and Members team.
+
+Some duties include:
+
+* Setting overall technical & community leadership
+* Engaging end-user community to advocate needs of end-users and to capture case-studies
+* Defining and curating roadmap for OpenFaaS & OpenFaaS Cloud
+* Building a community and team of contributors
+* Community & media briefings, out-bound communications, partnerships, relationship management and events
 
 ### How do I become a maintainer?
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update Governance and Team structure

Updated verbiage from "contributors" to "team" for members and
core. Added project sponsor OpenFaaS Ltd, trademark and additional
perks / benefits for members.

## Motivation and Context

Setting norms, ground-rules, perks and vision for voluntary teams.
