### PR TITLE
Set expectations for those seeking free support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,54 @@ If you have a deeply technical request or need help debugging your application t
 
 If you feel there is an issue with OpenFaaS or were unable to get the help you needed from the Slack channels then raise an issue on one of the GitHub repositories.
 
+#### Setting expectations, support and SLAs
+
+* What kind of support can I expect for free?
+
+    If you are using one of the Open Source projects within the openfaas or openfaas-incubator repository, then help is offered on a good-will basis by volunteers. You can also request help from employees of OpenFaaS Ltd who host the OpenFaaS projects.
+
+    Please be respectful of volunteer time, it is often limited to evenings and weekends. The person you are requesting help from may not reside in your timezone. 
+
+    The Slack workspace is the best place to ask questions, suggest features, and to get help. The GitHub issue tracker can be used for suspected issues with the codebase or deployment artifacts.
+
+* What is the SLA for my Issue?
+
+    Issues are examined, triaged and answered on a best effort basis by volunteers and community contributors. This means that you may receive an initial response within any time period such as: 1 minute, 1 hour, 1 day, or 1 week. There is no implicit meaning to the time between you raising an issue and it being answered or resolved.
+
+    If you see an issue which does not have a response or does not have a resolution, it does not mean that it is not important, or that it is being ignored. It simply means it has not been worked on by a volunteer yet.
+
+    Please take responsibility for following up on your Issues if you feel further action is required.
+
+* What is the SLA for my Pull Request?
+
+    In a similar way to Issues, Pull Requests are triaged, reviewed, and considered by a team of volunteers - the Core Team,  Members Team and the Project Lead. There are dozens of components that make up the OpenFaaS project and a limited amount of people. Sometimes PRs may become blocked or require further action.
+    
+    Please take responsibility for following up on your Pull Requests if you feel further action is required.
+    
+* Why may your PR be delayed?
+
+    * The contributing guide was not followed in some way
+
+    * The commits are not signed-off (the Derek bot will try to help you)
+
+    * The commits need to be rebased
+
+    * Changes have been requested
+
+    More information, a use-case, or context may be required for the change to be accepted.
+
+* What if I need more than that?
+
+    If you're a company using any of these projects, you can get the following through a support agreement with OpenFaaS Ltd so that the time can be paid for to help your business.
+
+    A support agreement can be tailored to your needs, you may benefit from support, if you need any of the following:
+
+    * responses within N hours/days on issues/PRs
+    * feature prioritisation
+    * urgent help
+    * 1:1 consultations
+    * or any other level of professional services
+
 #### I need to add a dependency
 
 The concept of `vendoring` is used in projects written in Go. This means that a copy of the source-code of dependencies is stored within each repository in the `vendor` folder. It allows for a repeatable build and isolates change.
@@ -147,9 +195,9 @@ How are credentials managed for quay.io and the Docker Hub? These credentials ar
 
 ## Governance
 
-OpenFaaS is an independent open-source project which was created by the Project Lead Alex Ellis in 2016. OpenFaaS is now being built by Alex, a number of volunteer teams, and a wider community of open-source developers.
+OpenFaaS is an independent open-source project which was created by the Project Lead Alex Ellis in 2016. OpenFaaS is now hosted by OpenFaaS Ltd. The project is maintained and developed by a number of regular volunteers and a wider community of open-source developers.
 
-OpenFaaS Ltd (company no. 11076587) sponsors the development and maintenance of OpenFaaS. OpenFaaS Ltd provides professional services, consultation and support. Email: [sales@openfaas.com](mailto:sales@openfaas.com) to make a query.
+OpenFaaS Ltd (company no. 11076587) hosts and sponsors the development and maintenance of OpenFaaS. OpenFaaS Ltd provides professional services, consultation and support. Email: [sales@openfaas.com](mailto:sales@openfaas.com) to find out more.
 
 OpenFaaS &reg; is a registered trademark in England and Wales.
 


### PR DESCRIPTION
False expectations from commercial users has been a source of
contention in Open Source since the beginning. This is designed
to help bring some empathy and understanding, and set more
realistic expectations for commerical users.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>
