### PR TITLE
Include Ratehub in the list of OpenFaaS adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -52,6 +52,8 @@ This is a list of adopters of OpenFaaS
 
 * [Press Association](https://www.pressassociation.com/) - Press Association is using OpenFaaS in development and production as part of our deployment pipeline.
 
+* [Ratehub](https://www.ratehub.ca) - Ratehub is Canada's leading personal finance comparison site. We're breaking apart our monolithic PHP and Java codebases into Node, PHP and Java OpenFaaS functions; there's not much that we don't plan on moving to FaaS!
+
 * [Transmute Industries](https://www.transmute.industries/) - "At Transmute we use OpenFaaS to develop identity and access integrations leveraging decentralized identities that integrate with legacy IAM systems. OpenFaaS helps Transmute and our customers avoid vendor lock in, encourages modularity, and helps us rapidly develop and release integrations for customers."
 
 * [Traversals](https://traversals.com/) - At Traversals, we use OpenFaaS for processing of incoming data. We take benefit from various programming languages available in OpenFaaS.


### PR DESCRIPTION
Updated ADOPTERS.md to Include Ratehub

Signed-off-by: Chris Richard <chris.richard@ratehub.ca>
