### PR TITLE
Update swam provider version in compose to 0.8.2

### DIFF
--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.15.3-arm64
+        image: openfaas/gateway:0.18.2-arm64
         networks:
             - functions
         environment:
@@ -16,7 +16,7 @@ services:
             faas_nats_port: 4222
             direct_functions: "true"        # Functions are invoked directly over the overlay network
             direct_functions_suffix: ""
-            basic_auth: "${BASIC_AUTH:-true}"
+            basic_auth: "${BASIC_AUTH:-false}"
             secret_mount_path: "/run/secrets/"
             scale_from_zero: "true"         # Enable if you want functions to scale from 0/0 to min replica count upon invoke
             max_idle_conns: 1024
@@ -40,10 +40,10 @@ services:
         secrets:
             - basic-auth-user
             - basic-auth-password
-    
+
     # auth service provide basic-auth plugin for system APIs
     basic-auth-plugin:
-        image: openfaas/basic-auth-plugin:0.15.3-arm64
+        image: openfaas/basic-auth-plugin:0.18.2-arm64
         networks:
             - functions
         environment:
@@ -74,14 +74,14 @@ services:
     faas-swarm:
         volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
-        image:  openfaas/faas-swarm:0.6.2-arm64
+        image:  openfaas/faas-swarm:0.8.2-arm64
         networks:
             - functions
         environment:
             read_timeout:  "5m5s"       # set both here, and on your functions
             write_timeout: "5m5s"       # set both here, and on your functions
             DOCKER_API_VERSION: "1.30"
-            basic_auth: "${BASIC_AUTH:-true}"
+            basic_auth: "${BASIC_AUTH:-false}"
             secret_mount_path: "/run/secrets/"
             gateway_invoke: "true"
             faas_gateway_address: "gateway"
@@ -125,13 +125,13 @@ services:
                     - 'node.platform.os == linux'
 
     queue-worker:
-        image: openfaas/queue-worker:0.7.2-arm64
+        image: openfaas/queue-worker:0.8.1-arm64
         networks:
             - functions
         environment:
             max_inflight: "1"
             ack_wait: "5m5s"    # Max duration of any async task / request
-            basic_auth: "${BASIC_AUTH:-true}"
+            basic_auth: "${BASIC_AUTH:-false}"
             secret_mount_path: "/run/secrets/"
         deploy:
             resources:

--- a/docker-compose.armhf.yml
+++ b/docker-compose.armhf.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.17.3-armhf
+        image: openfaas/gateway:0.18.2-armhf
         networks:
             - functions
         environment:
@@ -16,7 +16,7 @@ services:
             faas_nats_port: 4222
             direct_functions: "true" # Functions are invoked directly over the overlay network
             direct_functions_suffix: ""
-            basic_auth: "${BASIC_AUTH:-true}"
+            basic_auth: "${BASIC_AUTH:-false}"
             secret_mount_path: "/run/secrets/"
             scale_from_zero: "true" # Enable if you want functions to scale from 0/0 to min replica count upon invoke
             max_idle_conns: 1024
@@ -40,10 +40,10 @@ services:
         secrets:
             - basic-auth-user
             - basic-auth-password
-    
+
     # auth service provide basic-auth plugin for system APIs
     basic-auth-plugin:
-        image: openfaas/basic-auth-plugin:0.15.4-armhf
+        image: openfaas/basic-auth-plugin:0.18.2-armhf
         networks:
             - functions
         environment:
@@ -73,14 +73,14 @@ services:
     faas-swarm:
         volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
-        image:  openfaas/faas-swarm:0.7.1-armhf
+        image:  openfaas/faas-swarm:0.8.2-armhf
         networks:
             - functions
         environment:
             read_timeout:  "5m5s"       # set both here, and on your functions
             write_timeout: "5m5s"       # set both here, and on your functions
             DOCKER_API_VERSION: "1.30"
-            basic_auth: "${BASIC_AUTH:-true}"
+            basic_auth: "${BASIC_AUTH:-false}"
             secret_mount_path: "/run/secrets/"
         deploy:
             placement:
@@ -122,13 +122,13 @@ services:
                     - 'node.platform.os == linux'
 
     queue-worker:
-        image: openfaas/queue-worker:0.7.2-armhf
+        image: openfaas/queue-worker:0.8.1-armhf
         networks:
             - functions
         environment:
             max_inflight: "1"
             ack_wait: "5m5s"    # Max duration of any async task / request
-            basic_auth: "${BASIC_AUTH:-true}"
+            basic_auth: "${BASIC_AUTH:-false}"
             secret_mount_path: "/run/secrets/"
             gateway_invoke: "true"
             faas_gateway_address: "gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     gateway:
         ports:
             - 8080:8080
-        image: openfaas/gateway:0.17.3
+        image: openfaas/gateway:0.18.2
         networks:
             - functions
         environment:
@@ -16,7 +16,7 @@ services:
             faas_nats_port: 4222
             direct_functions: "true" # Functions are invoked directly over the overlay network
             direct_functions_suffix: ""
-            basic_auth: "${BASIC_AUTH:-true}"
+            basic_auth: "${BASIC_AUTH:-false}"
             secret_mount_path: "/run/secrets/"
             scale_from_zero: "true" # Enable if you want functions to scale from 0/0 to min replica count upon invoke
             max_idle_conns: 1024
@@ -43,7 +43,7 @@ services:
 
     # auth service provide basic-auth plugin for system APIs
     basic-auth-plugin:
-        image: openfaas/basic-auth-plugin:0.17.0
+        image: openfaas/basic-auth-plugin:0.18.2
         networks:
             - functions
         environment:
@@ -73,14 +73,14 @@ services:
     faas-swarm:
         volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
-        image: openfaas/faas-swarm:0.7.3
+        image: openfaas/faas-swarm:0.8.2
         networks:
             - functions
         environment:
             read_timeout: "5m5s" # set both here, and on your functions
             write_timeout: "5m5s" # set both here, and on your functions
             DOCKER_API_VERSION: "1.30"
-            basic_auth: "${BASIC_AUTH:-true}"
+            basic_auth: "${BASIC_AUTH:-false}"
             secret_mount_path: "/run/secrets/"
         deploy:
             placement:
@@ -122,13 +122,13 @@ services:
                     - "node.platform.os == linux"
 
     queue-worker:
-        image: openfaas/queue-worker:0.8.0
+        image: openfaas/queue-worker:0.8.1
         networks:
             - functions
         environment:
             max_inflight: "1"
             ack_wait: "5m5s" # Max duration of any async task / request
-            basic_auth: "${BASIC_AUTH:-true}"
+            basic_auth: "${BASIC_AUTH:-false}"
             secret_mount_path: "/run/secrets/"
             gateway_invoke: "true"
             faas_gateway_address: "gateway"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Bump faas-swarm version to latest, 0.8.2
- Bump arm64 and armhf services to their latest versions
- The docker-compose files were invalid when deployed directly because
  the auth url was not configured.  Set the default for basic auth to
  false to make this a valid configuration

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label

This is require to keep the swarm installation up to date with the latest release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have deployed to my local docker swarm (on Mac) using the standard `./deploy_stack.sh`, with basic auth enabled.  I was able to access the web UI, deploy, and invoke a function. As usual.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
