### PR TITLE
Hide the namespace selector when on swarm or <2 K8s ns

### DIFF
--- a/gateway/assets/index.html
+++ b/gateway/assets/index.html
@@ -54,9 +54,9 @@
                         </md-list-item>
                     </md-list>
 
-                    <md-input-container>
+                    <md-input-container ng-show="allNamespaces.length > 1">
                         <label>Namespace</label>
-                        <md-select  ng-model="namespaceSelect" placeholder="Select a Namespace">
+                        <md-select  ng-model="namespaceSelectDropdown" placeholder="Select a Namespace">
                             <md-option ng-click="setNamespace(namespace)" ng-value="namespace" ng-repeat="namespace in allNamespaces">
                                 {{ namespace }}
                             </md-option>
@@ -127,7 +127,7 @@
                                     <input ng-model="function.invocationCount" type="text" readonly="readonly">
                                 </md-input-container>
 
-                                <md-input-container class="md-block" flex-gt-sm>
+                                <md-input-container class="md-block" flex-gt-sm ng-show="allNamespaces.length > 1">
                                     <label>Namespace</label>
                                     <input ng-model="function.namespace" type="text" readonly="readonly">
                                 </md-input-container>

--- a/gateway/assets/script/bootstrap.js
+++ b/gateway/assets/script/bootstrap.js
@@ -23,7 +23,6 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$interval', '$f
             contentType: "text"
         };
 
-        $scope.namespaceSelect = $scope.selectedNamespace;
         $scope.baseUrl = $location.absUrl().replace(/\ui\/$/, '');
         try {
             $scope.canCopyToClipboard = document.queryCommandSupported('copy');
@@ -42,6 +41,8 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$interval', '$f
             var msg = copySuccessful ? 'Copied to Clipboard' : 'Copy failed. Please copy it manually';
             showPostInvokedToast(msg);
         }
+
+
 
         $scope.toggleSideNav = function() {
             $mdSidenav('left').toggle();
@@ -310,7 +311,7 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$interval', '$f
                 $scope.labelsToLabelInputs(func.labels);
                 $scope.annotationsToAnnotationInputs(func.annotations);
                 $scope.secretsToSecretInputs(func.secrets);
-                $scope.item.namespace = func.selectedNamespace;
+                $scope.item.namespace = $scope.namespaceSelected();
 
 
                 $scope.selectedFunc = func;
@@ -364,6 +365,10 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$interval', '$f
                         $scope.validationError = error1.data;
                     });
             };
+
+            $scope.fnNamespaceSelected = function(inputNamespace) {
+                $scope.namespaceSelect = inputNamespace;
+            }
 
             $scope.onEnvInputExpand = function() {
                 $scope.envFieldsVisible = !$scope.envFieldsVisible;

--- a/gateway/assets/templates/newfunction.html
+++ b/gateway/assets/templates/newfunction.html
@@ -58,12 +58,12 @@
                                 <input name="network" ng-model="item.network" md-maxlength="200" minlength="0">
                             </md-input-container>
                         </div>
-                        <div layout-gt-xs="row">
+                        <div layout-gt-xs="row" ng-if="allNamespaces.length > 1">
                             <md-input-container class="md-block" flex-gt-sm>
                                 <md-tooltip md-direction="bottom">Namespace your function runs in i.e. 'openfaas-fn'. Only namespaces OpenFaaS can manage will show here</md-tooltip>
                                 <label>Namespace</label>
                                 <md-select name="namespace" ng-model="namespaceSelect" placeholder="Select a Namespace">
-                                    <md-option ng-value="namespace" ng-repeat="namespace in allNamespaces">
+                                    <md-option ng-click="fnNamespaceSelected(namespace)" ng-value="namespace" ng-repeat="namespace in allNamespaces">
                                         {{ namespace }}
                                     </md-option>
                                 </md-select>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

We now hide the new namespace dropdown selector when
there is only 1 namespace, or when we are on swarm
This is also hidden in the function create page and
the function detail page

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>
closes #1391 
<!--- Provide a general summary of your changes in the Title above -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label
<img width="1354" alt="Screenshot 2019-12-15 at 14 28 42" src="https://user-images.githubusercontent.com/40488132/70865657-ca9b1b80-1f57-11ea-9864-5263d9f39377.png">
<img width="1169" alt="Screenshot 2019-12-15 at 14 28 35" src="https://user-images.githubusercontent.com/40488132/70865658-cb33b200-1f57-11ea-903b-24a7cda8d534.png">
<img width="1218" alt="Screenshot 2019-12-15 at 14 28 28" src="https://user-images.githubusercontent.com/40488132/70865659-cb33b200-1f57-11ea-95d1-6045580e08a8.png">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed to Swarm, namespace selectors all hidden, can create invoke and delete functions
Deployed to k8s with 1 namespace, its all hidden and create/invoke/delete work
Deployed to k8s with >1 ns, its visible, selectable and we can create, invoke and delete functions in each ns

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
