### PR TITLE
Change how and when we fetch and parse namespace info

### DIFF
--- a/gateway/assets/index.html
+++ b/gateway/assets/index.html
@@ -54,10 +54,10 @@
                         </md-list-item>
                     </md-list>
 
-                    <md-input-container ng-show="allNamespaces.length > 1">
+                    <md-input-container ng-show="allNamespaces.length > 1" class="display-flex">
                         <label>Namespace</label>
                         <md-select  ng-model="namespaceSelectDropdown" placeholder="Select a Namespace">
-                            <md-option ng-click="setNamespace(namespace)" ng-value="namespace" ng-repeat="namespace in allNamespaces">
+                            <md-option ng-click="setNamespace(namespace)" ng-value="namespace" ng-repeat="namespace in allNamespaces" ng-selected="namespace === selectedNamespace">
                                 {{ namespace }}
                             </md-option>
                         </md-select>
@@ -140,7 +140,7 @@
                                 </md-input-container>
                                 <md-input-container class="md-block function-url" flex-gt-sm>
                                     <label>URL</label>
-                                    <input ng-value="function.namespace === 'openfaas-fn' ? baseUrl + 'function/' + function.name : baseUrl + 'function/' + function.name + '.' + function.namespace" type="text" readonly="readonly">
+                                    <input ng-value="(function.namespace && function.namespace.length > 0)? baseUrl + 'function/' + function.name + '.' + function.namespace : baseUrl + 'function/' + function.name" type="text" readonly="readonly">
                                     <md-icon ng-if="canCopyToClipboard" md-svg-src="img/icons/outline-file_copy-24px.svg" ng-click="copyClicked($event)"></md-icon>
                                 </md-input-container>
                             </div>

--- a/gateway/assets/style/bootstrap.css
+++ b/gateway/assets/style/bootstrap.css
@@ -146,3 +146,6 @@ md-input-container.function-url md-icon {
     color: red;
 }
 
+.display-flex {
+    display: flex;
+}

--- a/gateway/assets/templates/newfunction.html
+++ b/gateway/assets/templates/newfunction.html
@@ -63,7 +63,7 @@
                                 <md-tooltip md-direction="bottom">Namespace your function runs in i.e. 'openfaas-fn'. Only namespaces OpenFaaS can manage will show here</md-tooltip>
                                 <label>Namespace</label>
                                 <md-select name="namespace" ng-model="namespaceSelect" placeholder="Select a Namespace">
-                                    <md-option ng-click="fnNamespaceSelected(namespace)" ng-value="namespace" ng-repeat="namespace in allNamespaces">
+                                    <md-option ng-click="fnNamespaceSelected(namespace)" ng-value="namespace" ng-repeat="namespace in allNamespaces" ng-selected="namespace === namespaceSelect">
                                         {{ namespace }}
                                     </md-option>
                                 </md-select>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The initial namespace select implementation had some challenges, especially around non-default installs (no openfaas-fn namespace)
This has removed lots of those issues and added some more user friendly bits too (defaulting to first returned namespace from backend, passing that namespace to the function-create as default)


Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label
closes #1408 
closes #1408 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
kubernetes:
Install with 4 active namespaces, switching works, adding a fn works (for each namespace)
Can add the same fn to each namespace
Can call each fn, see it calls correct one in logs
Can delete functions

Swarm:
No NS selector, can create, call and delete fns.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
