### PR TITLE
Always apply the function prefix trim for async functions

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -87,13 +87,14 @@ func main() {
 	var functionURLResolver handlers.BaseURLResolver
 	var functionURLTransformer handlers.URLPathTransformer
 	nilURLTransformer := handlers.TransparentURLPathTransformer{}
+	trimURLTransformer := handlers.FunctionPrefixTrimmingURLPathTransformer{}
 
 	if config.DirectFunctions {
 		functionURLResolver = handlers.FunctionAsHostBaseURLResolver{
 			FunctionSuffix:    config.DirectFunctionsSuffix,
 			FunctionNamespace: config.Namespace,
 		}
-		functionURLTransformer = handlers.FunctionPrefixTrimmingURLPathTransformer{}
+		functionURLTransformer = trimURLTransformer
 	} else {
 		functionURLResolver = urlResolver
 		functionURLTransformer = nilURLTransformer
@@ -141,7 +142,7 @@ func main() {
 		}
 
 		faasHandlers.QueuedProxy = handlers.MakeNotifierWrapper(
-			handlers.MakeCallIDMiddleware(handlers.MakeQueuedProxy(metricsOptions, true, natsQueue, functionURLTransformer)),
+			handlers.MakeCallIDMiddleware(handlers.MakeQueuedProxy(metricsOptions, true, natsQueue, trimURLTransformer)),
 			forwardingNotifiers,
 		)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Always apply the `FunctionPrefixTrimmingURLPathTransformer` when enqueueing async function requests. This ensures that the context information sent to the function is correct.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label

Resolves openfaas/nats-queue-worker#85

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested locally 

```sh
$ kind version
kind v0.6.1 go1.13.4 darwin/amd64
$ kind create cluster
$ helm repo add openfaas https://openfaas.github.io/faas-netes/ && helm repo update
$ kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
$ helm upgrade openfaas --install openfaas/openfaas \
    --namespace openfaas  \
    --set functionNamespace=openfaas-fn \
    --set generateBasicAuth=true \
    --set gateway.directFunctions=false \
    --set queueWorker.gatewayInvoke=true \
    --set gateway.image=theaxer/gateway:fix-85
$ kubectl port-forward -n openfaas svc/gateway 31112:8080 &
$ faas-cli login -u admin --password $(kubectl -n openfaas get secret basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode)
$ faas-cli deploy --name pycho --image theaxer/pycho:latest --fprocess='python index.py'
$ faas-cli deploy --name env --image functions/alpine:latest --fprocess=env
$ curl -XPOST http://127.0.0.1:31112/async-function/env -H "X-Callback-Url: http://gateway.openfaas:8080/function/pycho"
$ faas-cli logs pycho
...
2019-12-25T14:39:09Z 2019/12/25 14:39:09 stdout: 4749653810100
2019-12-25T14:39:09Z Http_Method=POST
2019-12-25T14:39:09Z Http_ContentLength=0
2019-12-25T14:39:09Z Http_Path=/
2019-12-25T14:39:09Z Http_Host=10.244.0.14:8080
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
