### PR TITLE
Bump alpine to 3.11

### DIFF
--- a/auth/basic-auth/Dockerfile
+++ b/auth/basic-auth/Dockerfile
@@ -16,7 +16,7 @@ RUN license-check -path ./ --verbose=false "OpenFaaS Authors" "OpenFaaS Author(s
     go build --ldflags "-s -w" -a -installsuffix cgo -o handler . && \
     go test $(go list ./... | grep -v /vendor/) -cover
 
-FROM alpine:3.10 as ship
+FROM alpine:3.11 as ship
 # Add non-root user
 RUN addgroup -S app && adduser -S -g app app \
     && mkdir -p /home/app \

--- a/auth/basic-auth/Dockerfile.arm64
+++ b/auth/basic-auth/Dockerfile.arm64
@@ -14,7 +14,7 @@ RUN license-check -path ./ --verbose=false "OpenFaaS Authors" "OpenFaaS Author(s
  && go test $(go list ./... | grep -v /vendor/) -cover && \
  CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w" -a -installsuffix cgo -o handler .
 
-FROM alpine:3.10
+FROM alpine:3.11
 # Add non-root user
 RUN addgroup -S app && adduser -S -g app app \
     && mkdir -p /home/app \

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -40,7 +40,7 @@ RUN license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Authors" "Open
     -X github.com/openfaas/faas/gateway/types.Arch=${ARCH}"\
     -a -installsuffix cgo -o gateway .
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ARG ARCH="x86_64"
 

--- a/gateway/Dockerfile.arm64
+++ b/gateway/Dockerfile.arm64
@@ -33,7 +33,7 @@ RUN license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Project" "Open
     -X github.com/openfaas/faas/gateway/version.Version=${VERSION}" \
     -a -installsuffix cgo -o gateway .
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 LABEL org.label-schema.license="MIT" \
     org.label-schema.vcs-url="https://github.com/openfaas/faas" \

--- a/gateway/Dockerfile.armhf
+++ b/gateway/Dockerfile.armhf
@@ -33,7 +33,7 @@ RUN license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Project" "Open
     -X github.com/openfaas/faas/gateway/version.Version=${VERSION}" \
     -a -installsuffix cgo -o gateway .
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 LABEL org.label-schema.license="MIT" \
     org.label-schema.vcs-url="https://github.com/openfaas/faas" \

--- a/sample-functions/AlpineFunction/Dockerfile
+++ b/sample-functions/AlpineFunction/Dockerfile
@@ -1,6 +1,6 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog

--- a/sample-functions/AlpineFunction/Dockerfile.arm64
+++ b/sample-functions/AlpineFunction/Dockerfile.arm64
@@ -1,6 +1,6 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog

--- a/sample-functions/AlpineFunction/Dockerfile.armhf
+++ b/sample-functions/AlpineFunction/Dockerfile.armhf
@@ -1,6 +1,6 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog

--- a/sample-functions/BaseFunctions/R/Dockerfile
+++ b/sample-functions/BaseFunctions/R/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
 FROM artemklevtsov/r-alpine:latest
 

--- a/sample-functions/BaseFunctions/coffee/Dockerfile
+++ b/sample-functions/BaseFunctions/coffee/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
 FROM node:6.9.1-alpine
 

--- a/sample-functions/BaseFunctions/dncore/Dockerfile
+++ b/sample-functions/BaseFunctions/dncore/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
 FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as build
 

--- a/sample-functions/BaseFunctions/golang/Dockerfile
+++ b/sample-functions/BaseFunctions/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
 FROM golang:1.11-alpine
 ENV CGO_ENABLED=0

--- a/sample-functions/BaseFunctions/java/Dockerfile
+++ b/sample-functions/BaseFunctions/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
 FROM openjdk:8u121-jdk-alpine
 

--- a/sample-functions/BaseFunctions/node/Dockerfile
+++ b/sample-functions/BaseFunctions/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
 FROM node:6.9.1-alpine
 

--- a/sample-functions/BaseFunctions/python/Dockerfile
+++ b/sample-functions/BaseFunctions/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
 FROM python:2.7-alpine
 

--- a/sample-functions/CHelloWorld/src/Dockerfile
+++ b/sample-functions/CHelloWorld/src/Dockerfile
@@ -1,6 +1,6 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
-FROM alpine:3.10 as builder
+FROM alpine:3.11 as builder
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 

--- a/sample-functions/CaptainsIntent/Dockerfile
+++ b/sample-functions/CaptainsIntent/Dockerfile
@@ -1,6 +1,6 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
-FROM alpine:3.10
+FROM alpine:3.11
 RUN apk --update add nodejs nodejs-npm
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog

--- a/sample-functions/ChangeColorIntent/Dockerfile
+++ b/sample-functions/ChangeColorIntent/Dockerfile
@@ -1,6 +1,6 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
-FROM alpine:3.10
+FROM alpine:3.11
 RUN apk --update add nodejs nodejs-npm
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog

--- a/sample-functions/DockerHubStats/Dockerfile
+++ b/sample-functions/DockerHubStats/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
 FROM golang:1.11-alpine as builder
 ENV CGO_ENABLED=0
@@ -10,7 +10,7 @@ WORKDIR /go/src/github.com/openfaas/faas/sample-functions/DockerHubStats
 COPY . /go/src/github.com/openfaas/faas/sample-functions/DockerHubStats
 RUN set -ex && apk add make && make install
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 # Needed to reach the hub
 RUN apk --no-cache add ca-certificates 

--- a/sample-functions/DockerHubStats/Dockerfile.armhf
+++ b/sample-functions/DockerHubStats/Dockerfile.armhf
@@ -13,7 +13,7 @@ COPY . /go/src/github.com/openfaas/faas/sample-functions/DockerHubStats
 
 RUN make install
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 # Needed to reach the hub
 RUN apk --no-cache add ca-certificates 

--- a/sample-functions/HostnameIntent/Dockerfile
+++ b/sample-functions/HostnameIntent/Dockerfile
@@ -1,4 +1,7 @@
 FROM functions/alpine:latest
+
+USER root
+
 RUN apk --update add nodejs nodejs-npm
 
 COPY package.json   .
@@ -6,5 +9,8 @@ COPY handler.js     .
 COPY sample.json    .
 
 RUN npm i
+
+USER 1000
+
 ENV fprocess="node handler.js"
 CMD ["fwatchdog"]

--- a/sample-functions/MarkdownRender/Dockerfile
+++ b/sample-functions/MarkdownRender/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
 FROM golang:1.11-alpine as builder
 ENV CGO_ENABLED=0
@@ -13,7 +13,7 @@ COPY vendor vendor
 
 RUN go install
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog

--- a/sample-functions/Nmap/Dockerfile
+++ b/sample-functions/Nmap/Dockerfile
@@ -1,6 +1,6 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog

--- a/sample-functions/NodeInfo/Dockerfile
+++ b/sample-functions/NodeInfo/Dockerfile
@@ -1,11 +1,14 @@
 FROM functions/alpine:latest
 
+USER root
+
 RUN apk --update add nodejs nodejs-npm
 
 COPY package.json .
 COPY main.js .
 
 RUN npm i
+USER 1000
 
 ENV fprocess="node main.js"
 CMD ["fwatchdog"]

--- a/sample-functions/NodeInfo/Dockerfile.arm64
+++ b/sample-functions/NodeInfo/Dockerfile.arm64
@@ -1,11 +1,15 @@
 FROM functions/alpine:latest
 
+USER root
+
 RUN apk --update add nodejs nodejs-npm
 
 COPY package.json .
 COPY main.js .
 
 RUN npm i
+
+USER 1000
 
 ENV fprocess="node main.js"
 CMD ["fwatchdog"]

--- a/sample-functions/NodeInfo/Dockerfile.armhf
+++ b/sample-functions/NodeInfo/Dockerfile.armhf
@@ -1,11 +1,15 @@
 FROM functions/alpine:latest
 
+USER root
+
 RUN apk --update add nodejs nodejs-npm
 
 COPY package.json .
 COPY main.js .
 
 RUN npm i
+
+USER 1000
 
 ENV fprocess="node main.js"
 CMD ["fwatchdog"]

--- a/sample-functions/Phantomjs/Dockerfile
+++ b/sample-functions/Phantomjs/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
 FROM alexellis2/phantomjs-docker:latest
 

--- a/sample-functions/ResizeImageMagick/Dockerfile
+++ b/sample-functions/ResizeImageMagick/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
 FROM v4tech/imagemagick
 

--- a/sample-functions/ResizeImageMagick/Dockerfile.armhf
+++ b/sample-functions/ResizeImageMagick/Dockerfile.armhf
@@ -1,6 +1,6 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
-FROM arm32v6/alpine:3.10
+FROM arm32v6/alpine:3.11
 
 RUN apk --no-cache add imagemagick
 

--- a/sample-functions/SentimentAnalysis/Dockerfile
+++ b/sample-functions/SentimentAnalysis/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
 FROM python:2.7-alpine
 

--- a/sample-functions/SentimentAnalysis/Dockerfile.armhf
+++ b/sample-functions/SentimentAnalysis/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
 FROM arm32v7/python:2.7-slim
 

--- a/sample-functions/WebhookStash/Dockerfile
+++ b/sample-functions/WebhookStash/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.14.4 as watchdog
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
 
 FROM golang:1.11-alpine as builder
 ENV CGO_ENABLED=0
@@ -12,7 +12,7 @@ COPY handler.go .
 
 RUN go install
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog

--- a/sample-functions/WordCountFunction/Dockerfile
+++ b/sample-functions/WordCountFunction/Dockerfile
@@ -1,5 +1,10 @@
 FROM functions/alpine:latest
 
+USER root
+
 # Populate example here
 ENV fprocess="wc"
+
+USER 1000
+
 CMD ["fwatchdog"]

--- a/sample-functions/echo/Dockerfile
+++ b/sample-functions/echo/Dockerfile
@@ -1,2 +1,3 @@
 FROM functions/alpine:latest
+
 ENV fprocess "/bin/cat"

--- a/sample-functions/figlet/Dockerfile
+++ b/sample-functions/figlet/Dockerfile
@@ -1,8 +1,11 @@
 FROM functions/alpine:latest
 
+USER root
+
 RUN apk add --no-cache figlet
 
 ENV fprocess="figlet"
+USER 1000
 
 HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
 CMD ["fwatchdog"]

--- a/sample-functions/figlet/Dockerfile.armhf
+++ b/sample-functions/figlet/Dockerfile.armhf
@@ -1,7 +1,9 @@
 FROM functions/alpine:latest
+USER root
 
 RUN apk add --no-cache figlet
 
+USER 1000
 ENV fprocess="figlet"
 
 HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1

--- a/sample-functions/gif-maker/Dockerfile
+++ b/sample-functions/gif-maker/Dockerfile
@@ -1,7 +1,12 @@
 FROM functions/alpine:latest
 
+USER root
+
 RUN apk add ffmpeg gifsicle
 WORKDIR /root/
 COPY entry.sh   .
 ENV fprocess="./entry.sh"
+
+USER 1000
+
 CMD ["fwatchdog"]

--- a/sample-functions/pwgen/Dockerfile
+++ b/sample-functions/pwgen/Dockerfile
@@ -1,5 +1,9 @@
 FROM functions/alpine:latest
-	
+
+USER root
+
 RUN apk add --no-cache pwgen
+
+USER 1000
 
 ENV fprocess="xargs pwgen -s"


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description
<!--- Describe your changes in detail -->

Bump alpine to 3.11

## Motivation and Context

There's a new release which appears to have no apparent down-
sides or breakages.

https://www.alpinelinux.org/posts/Alpine-3.11.2-released.html

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The image worked on armhf and x86_64. The sample images have built as expected. The gateway will be tested before merging `openfaas/gateway:0.18.9-rc1` and CI will run smoke tests.