### PR TITLE
Add transfer-encoding to watchdog env-vars if present

### DIFF
--- a/watchdog/README.md
+++ b/watchdog/README.md
@@ -38,9 +38,9 @@ Here's how to package your function if you don't want to use the CLI or have exi
 Example Dockerfile for an `echo` function:
 
 ```
-FROM alpine:3.8
+FROM alpine:3.11
 
-ADD https://github.com/openfaas/faas/releases/download/0.9.14/fwatchdog /usr/bin
+ADD https://github.com/openfaas/faas/releases/download/0.18.10/fwatchdog /usr/bin
 RUN chmod +x /usr/bin/fwatchdog
 
 # Define your binary here
@@ -134,9 +134,10 @@ The `X-Forwarded-By` header becomes available as `Http_X_Forwarded_By`
 
 * `Http_Method` - GET/POST etc
 * `Http_Query` - QueryString value
-* `Http_ContentLength` - gives the total content-length of the incoming HTTP request received by the watchdog.
+* `Http_ContentLength` and `Http_Content_Length` - gives the total content-length of the incoming HTTP request received by the watchdog, see note below
+* `Http_Transfer_Encoding` - only set when provided, if set to `chunked` the Content-Length will be `-1` to show that it does not apply
 
-> This behaviour is enabled by the `cgi_headers` environmental variable which is enabled by default.
+> This behaviour is enabled by the `cgi_headers` environmental variable which is enabled (`true`) by default.
 
 Here's an example of a POST request with an additional header and a query-string.
 

--- a/watchdog/handler.go
+++ b/watchdog/handler.go
@@ -237,6 +237,10 @@ func getAdditionalEnvs(config *WatchdogConfig, r *http.Request, method string) [
 		envs = append(envs, fmt.Sprintf("Http_ContentLength=%d", r.ContentLength))
 		envs = append(envs, fmt.Sprintf("Http_Content_Length=%d", r.ContentLength))
 
+		if len(r.TransferEncoding) > 0 {
+			envs = append(envs, fmt.Sprintf("Http_Transfer_Encoding=%s", r.TransferEncoding[0]))
+		}
+
 		if config.writeDebug {
 			log.Println("Query ", r.URL.RawQuery)
 		}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add transfer-encoding to watchdog env-vars if present

## Motivation and Context
The Content-Type header must be ignored when the Transfer
Encoding is set to "chunked" because the length is unknown

Go sets this to -1 and we pass that onto the user:
https://golang.org/src/net/http/transfer.go

The value of Content_Length is currently set to -1 in this
scenario, however it caused some confusion for at least one
user in issue: #1422.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The Http_Transfer_Encoding value was tested by running the
watchdog on Linux with "env" as the fprocess and an extra
header to "curl"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
