### PR TITLE
Fix envvar handling in deploy_stack.ps1

### DIFF
--- a/deploy_stack.ps1
+++ b/deploy_stack.ps1
@@ -74,16 +74,19 @@ if (Get-Command docker -errorAction SilentlyContinue)
         Write-Host "Disabling basic authentication for gateway.."
         Write-Host ""
         $env:BASIC_AUTH="false";
+        $env:AUTH_URL=""
     }
     else 
     {
         Write-Host ""
         Write-Host "Enabling basic authentication for gateway.."
         Write-Host ""
+        $env:BASIC_AUTH="true";
+        $env:AUTH_URL="http://basic-auth-plugin:8080/validate"
     }
 
     Write-Host "Deploying OpenFaaS core services"
-    docker stack deploy func --compose-file ./docker-compose.yml  --orchestrator swarm
+    docker stack deploy func --compose-file ./docker-compose.yml
 }
 else
 {


### PR DESCRIPTION
## Description
Adds the missing `$env:BASIC_AUTH` and `$env:AUTH_URL` envvars to the windows `deploy_stack.ps1` script.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1308 
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed both with and without auth on Windows 10.

With auth - verified by logging in via incognito browser and confirming prompt for basic auth creds.
```
PS D:\workspace\github\openfaas\faas> powershell -ExecutionPolicy Bypass -File .\deploy_stack.ps1      
Attempting to create credentials for gateway..
[Credentials]
 username: admin
 password: 2a92d6f29b7a70495b9d25519c75b8d2612a9a61784fa56073931867de39f158
 Write-Output "2a92d6f29b7a70495b9d25519c75b8d2612a9a61784fa56073931867de39f158" | faas-cli login --username=admin --password-stdin

Enabling basic authentication for gateway..

Deploying OpenFaaS core services
Creating config func_alertmanager_config
Creating config func_prometheus_config
Creating config func_prometheus_rules
Creating service func_queue-worker
Creating service func_prometheus
Creating service func_alertmanager
Creating service func_gateway
Creating service func_basic-auth-plugin
Creating service func_faas-swarm
Creating service func_nats
```

With auth - verified by logging in via incognito browser and confirming **no** prompt for basic auth creds.
```
PS D:\workspace\github\openfaas\faas> powershell -ExecutionPolicy Bypass -File .\deploy_stack.ps1 -noAuth
Attempting to create credentials for gateway..
[Credentials]
 username: admin
 password: 643b6df63088dacc539fd7150e114de5698ef02b5b7dd87b41c115cc756ef904
 Write-Output "643b6df63088dacc539fd7150e114de5698ef02b5b7dd87b41c115cc756ef904" | faas-cli login --username=admin --password-stdin

Disabling basic authentication for gateway..

Deploying OpenFaaS core services
Creating config func_prometheus_rules
Creating config func_prometheus_config
Creating service func_faas-swarm
Creating service func_queue-worker
Creating service func_prometheus
Creating service func_alertmanager
Creating service func_gateway
Creating service func_basic-auth-plugin
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
