### PR TITLE
remove dead link to deprecated guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,4 +2,4 @@
 
 ![https://blog.alexellis.io/content/images/2017/08/faas_side.png](https://blog.alexellis.io/content/images/2017/08/faas_side.png)
 
-Please see the [official documentation site](https://docs.openfaas.com) or our [more detailed set of guides on GitHub](https://github.com/openfaas/faas/tree/master/guide).
+Please see the [official documentation site](https://docs.openfaas.com).


### PR DESCRIPTION
Looks like the guide been deprecated. I couldn't find a replacement, so I've just removed the link. 