### PR TITLE
travis: Test Against Go 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 
 language: go
 go:
-  - "1.13.x"
+  - "1.14.x"
 
 services:
       - docker


### PR DESCRIPTION
Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>

## Description

This PR updates `.travis.yml` to test against the current version of Go.