### PR TITLE
Require PowerShell Desktop Edition for deploy_stack.ps1

### DIFF
--- a/deploy_stack.ps1
+++ b/deploy_stack.ps1
@@ -1,4 +1,5 @@
 #!ps1
+#Requires -PSEdition Desktop
 
 param (
     [switch] $noAuth,


### PR DESCRIPTION
## Description
Currently, .NET Core does not support System.Web.dll which causes `[System.Web.Security.Membership]::GeneratePassword(14, 5)` to fail.

When running the script with a `Core` edition of PowerShell such as `6.0.0` or `7.0.0` the script runs but fails to generate a password. The script continues to completion with no way to access the UI or CLI since the password is unknown/no-set.

Here is the output of the script running in `7.0.0`.

```powershell
PS>.\deploy_stack.ps1
InvalidOperation: C:\Working\faas\deploy_stack.ps1:30
Line |
  30 |      $password = [System.Web.Security.Membership]::GeneratePassword(24 …
     |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Unable to find type [System.Web.Security.Membership].

MethodInvocationException: C:\Working\faas\deploy_stack.ps1:36
Line |
  36 |          $hash = $sha256.ComputeHash([System.Text.Encoding]::UTF8.GetB …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception calling "GetBytes" with "1" argument(s): "Array cannot be null. (Parameter 'chars')"

MethodInvocationException: C:\Working\faas\deploy_stack.ps1:38
Line |
  38 |          $secret = [System.BitConverter]::ToString($hash).Replace('-', …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception calling "ToString" with "1" argument(s): "Value cannot be null. (Parameter 'value')"

Attempting to create credentials for gateway..
```

## Motivation and Context
The reason for the change is to provide a way to notify the end user that PowerShell `Core` is not (currently) supported and must be run with a `Desktop` edition (such as `5.1`).

Here is a reference to the issue regarding .Net Core not supporting `system.web.dll`: https://github.com/PowerShell/PowerShell/issues/5352

## How Has This Been Tested?
Tested the `build_stack.ps1` script in both `Core` and `Desktop` editions of PowerShell with expected results.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
