### PR TITLE
Update password generation to support PS Core

### DIFF
--- a/deploy_stack.ps1
+++ b/deploy_stack.ps1
@@ -25,9 +25,7 @@ if (Get-Command docker -errorAction SilentlyContinue)
         throw "Docker not in swarm mode, please initialise the cluster (`docker swarm init`) and retry"
     }
 
-    # AE: would be nice to avoid this dependency.
-    Add-Type -AssemblyName System.Web
-    $password = [System.Web.Security.Membership]::GeneratePassword(24,5)
+    $password = -join ((33..126) * 120 | Get-Random -Count 24 | ForEach-Object { [char]$_ })
     $secret = ""
 
     if (-Not $noHash)


### PR DESCRIPTION
Signed-off-by: Kyle Parrish <arnydo@arnydo.com>

Fixes: #1475 

`Core` versions of PowerShell lack support for the `System.Web.dll` which causes `[System.Web.Security.Membership]::GeneratePassword(14, 5)` to fail.

Changed the password generation method to support all current versions of PowerShell.

## Description
To address the [lack of support for the `System.Web` assembly in PowerShell Core](https://github.com/PowerShell/PowerShell/issues/5352), the password generation process has been updated from: 
`$password = [System.Web.Security.Membership]::GeneratePassword(14, 5)`

To:
`$password = -join ((33..126) * 120 | Get-Random -Count 24 | ForEach-Object { [char]$_ })`

## Motivation and Context
When running the script with a `Core` edition of PowerShell such as `6.0.0` or `7.0.0` the script runs but fails to generate a password. The script continues to completion with no way to access the UI or CLI since the password is unknown/no-set.

Here is the output of the script running in `7.0.0`.

```powershell
PS>.\deploy_stack.ps1
InvalidOperation: C:\Working\faas\deploy_stack.ps1:30
Line |
  30 |      $password = [System.Web.Security.Membership]::GeneratePassword(24 …
     |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Unable to find type [System.Web.Security.Membership].

MethodInvocationException: C:\Working\faas\deploy_stack.ps1:36
Line |
  36 |          $hash = $sha256.ComputeHash([System.Text.Encoding]::UTF8.GetB …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception calling "GetBytes" with "1" argument(s): "Array cannot be null. (Parameter 'chars')"

MethodInvocationException: C:\Working\faas\deploy_stack.ps1:38
Line |
  38 |          $secret = [System.BitConverter]::ToString($hash).Replace('-', …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception calling "ToString" with "1" argument(s): "Value cannot be null. (Parameter 'value')"

Attempting to create credentials for gateway..
```
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
This has been tested in various versions of PowerShell, including:
* 2.0
* 5.1
* 7.0.0

The result is a randomly generated password.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
