### PR TITLE
Remove cname file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-docs.get-faas.com


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->


get-faas domain is no-longer used for github pages

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
