### PR TITLE
Forward original request's context

### DIFF
--- a/gateway/handlers/callid_middleware.go
+++ b/gateway/handlers/callid_middleware.go
@@ -4,6 +4,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -24,6 +25,20 @@ func MakeCallIDMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		r.Header.Add("X-Start-Time", fmt.Sprintf("%d", start.UTC().UnixNano()))
 		w.Header().Add("X-Start-Time", fmt.Sprintf("%d", start.UTC().UnixNano()))
 
+		printContextStatus(r.Context())
+
 		next(w, r)
+
+		printContextStatus(r.Context())
+	}
+}
+
+func printContextStatus(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+		fmt.Println("Context closed")
+		fmt.Println(ctx.Err())
+	default:
+		fmt.Println("Context is still valid")
 	}
 }

--- a/gateway/handlers/callid_middleware.go
+++ b/gateway/handlers/callid_middleware.go
@@ -4,7 +4,6 @@
 package handlers
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -25,20 +24,6 @@ func MakeCallIDMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		r.Header.Add("X-Start-Time", fmt.Sprintf("%d", start.UTC().UnixNano()))
 		w.Header().Add("X-Start-Time", fmt.Sprintf("%d", start.UTC().UnixNano()))
 
-		printContextStatus(r.Context())
-
 		next(w, r)
-
-		printContextStatus(r.Context())
-	}
-}
-
-func printContextStatus(ctx context.Context) {
-	select {
-	case <-ctx.Done():
-		fmt.Println("Context closed")
-		fmt.Println(ctx.Err())
-	default:
-		fmt.Println("Context is still valid")
 	}
 }

--- a/gateway/handlers/forwarding_proxy.go
+++ b/gateway/handlers/forwarding_proxy.go
@@ -123,7 +123,7 @@ func forwardRequest(w http.ResponseWriter,
 		log.Printf("forwardRequest: %s %s\n", upstreamReq.Host, upstreamReq.URL.String())
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
 	defer cancel()
 
 	res, resErr := proxyClient.Do(upstreamReq.WithContext(ctx))


### PR DESCRIPTION
This PR intends to fix #1500 by forwarding the original request's context.

## How Has This Been Tested?

Installed latest Openfaas helm chart on a k3s RPi cluster. Developed a simple application ([here](https://github.com/SpaWn2KiLl/openfaas-context-poc)) that simulates the needed time to cold start a function. The client was simulated by using curl with a timeout of 3 seconds. Requests were created targeting the node port and kubernetes service.

Also tested on a k8s Azure cluster with actual functions cold starting.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)