### PR TITLE
Remove service namespace from scale request

### DIFF
--- a/gateway/plugin/external.go
+++ b/gateway/plugin/external.go
@@ -27,13 +27,6 @@ type ExternalServiceQuery struct {
 	AuthInjector middleware.AuthInjector
 }
 
-// ScaleServiceRequest request scaling of replica
-type ScaleServiceRequest struct {
-	ServiceName      string `json:"serviceName"`
-	ServiceNamespace string `json:"serviceNamespace"`
-	Replicas         uint64 `json:"replicas"`
-}
-
 // NewExternalServiceQuery proxies service queries to external plugin via HTTP
 func NewExternalServiceQuery(externalURL url.URL, authInjector middleware.AuthInjector) scaling.ServiceQuery {
 	timeout := 3 * time.Second
@@ -134,10 +127,9 @@ func (s ExternalServiceQuery) GetReplicas(serviceName, serviceNamespace string) 
 func (s ExternalServiceQuery) SetReplicas(serviceName, serviceNamespace string, count uint64) error {
 	var err error
 
-	scaleReq := ScaleServiceRequest{
-		ServiceName:      serviceName,
-		Replicas:         count,
-		ServiceNamespace: serviceNamespace,
+	scaleReq := types.ScaleServiceRequest{
+		ServiceName: serviceName,
+		Replicas:    count,
 	}
 
 	requestBody, err := json.Marshal(scaleReq)


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Remove service namespace from scale request

## Motivation and Context

This field doesn't appear to be used and is supplied via the
querystring which faas-netes (the only ns-enabled provider
already consumes)

Related to PR:

https://github.com/openfaas/faas-netes/pull/671

## How Has This Been Tested?

Go test and local make with Dockerfile.
