### PR TITLE
Use rate[30s] for APIHighInvocationRate alert

### DIFF
--- a/prometheus/alert.rules.yml
+++ b/prometheus/alert.rules.yml
@@ -4,7 +4,7 @@ groups:
   - alert: service_down
     expr: up == 0
   - alert: APIHighInvocationRate
-    expr: sum(rate(gateway_function_invocation_total{code="200"}[10s])) BY (function_name) > 5
+    expr: sum(rate(gateway_function_invocation_total{code="200"}[30s])) BY (function_name) > 5
     for: 5s
     labels:
       service: gateway


### PR DESCRIPTION
The problem with rate[10s], because the gateway scrape interval is 5s,
is that it most likely only contains around 2 samples in the given
range.

Here's an excellent blog post on why 30s should be a lot better:
https://www.robustperception.io/what-range-should-i-use-with-rate

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I haven't tried this particular change personally, as it's just two characters changing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
