### PR TITLE
Update scaling polling interval

### DIFF
--- a/gateway/main.go
+++ b/gateway/main.go
@@ -137,7 +137,7 @@ func main() {
 	scalingConfig := scaling.ScalingConfig{
 		MaxPollCount:         uint(1000),
 		SetScaleRetries:      uint(20),
-		FunctionPollInterval: time.Millisecond * 50,
+		FunctionPollInterval: time.Millisecond * 100,
 		CacheExpiry:          time.Second * 5, // freshness of replica values before going stale
 		ServiceQuery:         externalServiceQuery,
 	}

--- a/gateway/plugin/external.go
+++ b/gateway/plugin/external.go
@@ -63,14 +63,16 @@ func (s ExternalServiceQuery) GetReplicas(serviceName, serviceNamespace string) 
 
 	urlPath := fmt.Sprintf("%ssystem/function/%s?namespace=%s", s.URL.String(), serviceName, serviceNamespace)
 
-	req, _ := http.NewRequest(http.MethodGet, urlPath, nil)
+	req, err := http.NewRequest(http.MethodGet, urlPath, nil)
+	if err != nil {
+		return emptyServiceQueryResponse, err
+	}
 
 	if s.AuthInjector != nil {
 		s.AuthInjector.Inject(req)
 	}
 
 	res, err := s.ProxyClient.Do(req)
-
 	if err != nil {
 		log.Println(urlPath, err)
 	} else {


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update scaling polling interval

## Motivation and Context
Polls every 100 ms instead of every 50ms for use with a new
faas-netes PR:

https://github.com/openfaas/faas-netes/pull/726

The call is much faster now, so this request should me made
at a lower frequency.

Also adds error handling for URL building in the external
service query code.

## How Has This Been Tested?

Tested in the faas-netes PR at 150ms which seemed too slow, so this PR just adds
50ms to the interval.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
