### PR TITLE
Add Dockerfile.arm64 for Figlet and SentimentalAnalysis #1587

### DIFF
--- a/sample-functions/SentimentAnalysis/Dockerfile.arm64
+++ b/sample-functions/SentimentAnalysis/Dockerfile.arm64
@@ -1,0 +1,32 @@
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
+
+FROM arm64v8/python:3-alpine
+
+RUN apk add --no-cache gcc \
+    musl-dev
+
+RUN pip install textblob && \
+    python -m textblob.download_corpora
+
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+
+RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
+USER 1000
+
+WORKDIR /home/app
+
+COPY requirements.txt   .
+RUN pip install -r requirements.txt
+
+RUN python -m textblob.download_corpora
+
+COPY handler3.py ./handler.py
+ENV fprocess="python handler.py"
+ENV PYTHONIOENCODING="UTF-8"
+
+HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
+
+CMD ["fwatchdog"]
+
+

--- a/sample-functions/SentimentAnalysis/handler3.py
+++ b/sample-functions/SentimentAnalysis/handler3.py
@@ -1,0 +1,33 @@
+import sys
+import importlib
+import json
+from textblob import TextBlob
+
+# Set encoding to UTF-8 (vs ASCII to eliminate potential errors).
+importlib.reload(sys)
+
+def get_stdin():
+    buf = ""
+    for line in sys.stdin:
+        buf = buf + line
+    return buf
+
+if __name__ == "__main__":
+    st = get_stdin()
+    blob = TextBlob(st)
+    res = {
+        "polarity": 0,
+        "subjectivity": 0
+    }
+
+    for sentence in blob.sentences:
+        res["subjectivity"] = res["subjectivity"] + sentence.sentiment.subjectivity
+        res["polarity"] = res["polarity"] + sentence.sentiment.polarity
+
+    total = len(blob.sentences)
+
+    res["sentence_count"] = total
+    res["polarity"] = res["polarity"] / total
+    res["subjectivity"] = res["subjectivity"] / total
+
+    print(json.dumps(res))

--- a/sample-functions/figlet/Dockerfile.arm64
+++ b/sample-functions/figlet/Dockerfile.arm64
@@ -1,0 +1,10 @@
+FROM functions/alpine:latest-arm64 
+USER root
+
+RUN apk add --no-cache figlet
+
+USER 1000
+ENV fprocess="figlet"
+
+HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
+CMD ["fwatchdog"]


### PR DESCRIPTION
Updated handler code for sentimental analysis to work with python3
Signed-off-by: Palash Oswal <oswalpalash@gmail.com>


## Motivation and Context
Addresses #1587 

## How Has This Been Tested?
```
[tester@k8s SentimentAnalysis]$ uname -r
4.18.0-240.1.1.el8_3.aarch64
[tester@k8s SentimentAnalysis]$ echo "This is a test statement. The man was confused and didn't know what to do" | faas-cli invoke sentimentalanalysis
{"polarity": -0.2, "subjectivity": 0.35, "sentence_count": 2}
[tester@k8s SentimentAnalysis]$ echo "TEST" | faas-cli invoke figlet
 _____ _____ ____ _____ 
|_   _| ____/ ___|_   _|
  | | |  _| \___ \ | |  
  | | | |___ ___) || |  
  |_| |_____|____/ |_|  

With the images oswalpalash/figlet:arm64 and oswalpalash/sentimentalanalysis:arm64
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
