### PR TITLE
Restore the X-Call-Id for synchronous calls

### DIFF
--- a/gateway/main.go
+++ b/gateway/main.go
@@ -117,7 +117,9 @@ func main() {
 
 	decorateExternalAuth := handlers.MakeExternalAuthHandler
 
-	faasHandlers.Proxy = handlers.MakeForwardingProxyHandler(reverseProxy, functionNotifiers, functionURLResolver, functionURLTransformer, nil)
+	faasHandlers.Proxy = handlers.MakeCallIDMiddleware(
+		handlers.MakeForwardingProxyHandler(reverseProxy, functionNotifiers, functionURLResolver, functionURLTransformer, nil),
+	)
 
 	faasHandlers.ListFunctions = handlers.MakeForwardingProxyHandler(reverseProxy, forwardingNotifiers, urlResolver, nilURLTransformer, serviceAuthInjector)
 	faasHandlers.DeployFunction = handlers.MakeForwardingProxyHandler(reverseProxy, forwardingNotifiers, urlResolver, nilURLTransformer, serviceAuthInjector)
@@ -181,8 +183,6 @@ func main() {
 
 	prometheusQuery := metrics.NewPrometheusQuery(config.PrometheusHost, config.PrometheusPort, &http.Client{})
 	faasHandlers.ListFunctions = metrics.AddMetricsHandler(faasHandlers.ListFunctions, prometheusQuery)
-	faasHandlers.Proxy = handlers.MakeCallIDMiddleware(faasHandlers.Proxy)
-
 	faasHandlers.ScaleFunction = handlers.MakeForwardingProxyHandler(reverseProxy, forwardingNotifiers, urlResolver, nilURLTransformer, serviceAuthInjector)
 
 	if credentials != nil {


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Restore the X-Call-Id for synchronous calls

## Motivation and Context

This appears to have been removed inadvertently whilst
adding scale from zero logic into the gateway.

Going forward, synchronous and asynchronous calls will have a
header populated.

Fixes: #1624 

## How Has This Been Tested?

The "env" function can be used to print headers and show the behaviour before, and after.

Verify previous behaviour with:

```
arkade install openfaas \
  --set gateway.image=alexellis2/gateway:0.1.0

faas-cli deploy --name env --fprocess env \
  --image functions/alpine:latest-multiarch

curl localhost:8080/function/env

Http_User_Agent=curl/7.72.0
Http_Accept=*/*
Http_X_Forwarded_For=127.0.0.1:42484
Http_X_Forwarded_Host=localhost:8080
Http_Accept_Encoding=gzip
Http_Method=GET
Http_ContentLength=0
Http_Content_Length=0
Http_Path=/
Http_Host=env.openfaas-fn.svc.cluster.local:8080
```

And after with:

```
arkade install openfaas \
  --set gateway.image=alexellis2/gateway:0.1.1

faas-cli deploy --name env --fprocess env \
  --image functions/alpine:latest-multiarch

curl localhost:8080/function/env

Http_X_Start_Time=1612950236738385553
Http_Accept_Encoding=gzip
Http_User_Agent=curl/7.72.0
Http_Accept=*/*
Http_X_Call_Id=8cd853a4-153c-43a2-a147-90d5d05d284d
Http_X_Forwarded_For=127.0.0.1:45576
Http_X_Forwarded_Host=localhost:8080
Http_Method=GET
Http_ContentLength=0
Http_Content_Length=0
Http_Path=/
Http_Host=env.openfaas-fn.svc.cluster.local:8080
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
