### PR TITLE
Add explicit test for the logging notifier middleware

### DIFF
--- a/gateway/handlers/notifier_wrapper_test.go
+++ b/gateway/handlers/notifier_wrapper_test.go
@@ -4,8 +4,12 @@
 package handlers
 
 import (
+	"bytes"
+	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -86,4 +90,124 @@ type testNotifier struct {
 // Notify about service metrics
 func (tf *testNotifier) Notify(method string, URL string, originalURL string, statusCode int, event string, duration time.Duration) {
 	tf.StatusReceived = statusCode
+}
+
+func TestLoggingMiddleware(t *testing.T) {
+
+	logger := LoggingNotifier{}
+	cases := []struct {
+		name   string
+		status int
+		method string
+		path   string
+	}{
+		{
+			name:   "logs successful GET request",
+			status: http.StatusOK,
+			method: http.MethodGet,
+			path:   "/a/b/c",
+		},
+		{
+			name:   "logs successful POST request",
+			status: http.StatusOK,
+			method: http.MethodPost,
+			path:   "/a/b/c",
+		},
+		{
+			name:   "logs successful PATCH request",
+			status: http.StatusOK,
+			method: http.MethodPatch,
+			path:   "/a/b/c",
+		},
+		{
+			name:   "logs successful PUT request",
+			status: http.StatusOK,
+			method: http.MethodPut,
+			path:   "/a/b/c",
+		},
+		{
+			name:   "logs successful DELETE request",
+			status: http.StatusOK,
+			method: http.MethodDelete,
+			path:   "/a/b/c",
+		},
+		{
+			name:   "logs successful OPTIONS request",
+			status: http.StatusOK,
+			method: http.MethodOptions,
+			path:   "/a/b/c",
+		},
+		{
+			name:   "logs 201 success",
+			status: http.StatusCreated,
+			method: http.MethodGet,
+			path:   "/a/b/c",
+		},
+		{
+			name:   "logs 204 success",
+			status: http.StatusNoContent,
+			method: http.MethodGet,
+			path:   "/a/b/c",
+		},
+		{
+			name:   "logs 400 failure",
+			status: http.StatusBadRequest,
+			method: http.MethodGet,
+			path:   "/a/b/c",
+		},
+		{
+			name:   "logs 401 failure",
+			status: http.StatusUnauthorized,
+			method: http.MethodGet,
+			path:   "/a/b/c",
+		},
+		{
+			name:   "logs 403 failure",
+			status: http.StatusForbidden,
+			method: http.MethodGet,
+			path:   "/a/b/c",
+		},
+		{
+			name:   "logs 500 failure",
+			status: http.StatusInternalServerError,
+			method: http.MethodGet,
+			path:   "/a/b/c",
+		},
+		{
+			name:   "logs 301 redirect",
+			status: http.StatusMovedPermanently,
+			method: http.MethodGet,
+			path:   "/a/b/c",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var b bytes.Buffer
+			log.SetOutput(&b)
+			log.SetFlags(0)
+			log.SetPrefix("")
+
+			handler := MakeNotifierWrapper(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+			}, []HTTPNotifier{logger})
+
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tc.status {
+				t.Fatalf("unexpected status code, expected %d, got %d", tc.status, rec.Code)
+			}
+
+			logs := b.String()
+
+			prefix := fmt.Sprintf("Forwarded [%s] to %s - [%d] -", tc.method, tc.path, tc.status)
+			if !strings.HasPrefix(logs, prefix) {
+				t.Fatalf("expected log to start with: %q\ngot: %q", prefix, logs)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Add unit test that verifies the behavior of the logging middleware in
  various response cases

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label

An issue with logging came up in Slack and this shows that the issue is not in the notification or logging middlewares

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It is a unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
