### PR TITLE
Gateway: Add basic auth configurability for Prometheus

### DIFF
--- a/gateway/main.go
+++ b/gateway/main.go
@@ -181,7 +181,7 @@ func main() {
 		)
 	}
 
-	prometheusQuery := metrics.NewPrometheusQuery(config.PrometheusHost, config.PrometheusPort, &http.Client{})
+	prometheusQuery := metrics.NewPrometheusQuery(config.PrometheusHost, config.PrometheusPort, config.PrometheusUser, config.PrometheusPassword, &http.Client{})
 	faasHandlers.ListFunctions = metrics.AddMetricsHandler(faasHandlers.ListFunctions, prometheusQuery)
 	faasHandlers.ScaleFunction = handlers.MakeForwardingProxyHandler(reverseProxy, forwardingNotifiers, urlResolver, nilURLTransformer, serviceAuthInjector)
 

--- a/gateway/metrics/prometheus_query.go
+++ b/gateway/metrics/prometheus_query.go
@@ -9,9 +9,11 @@ import (
 
 // PrometheusQuery represents parameters for querying Prometheus
 type PrometheusQuery struct {
-	Port   int
-	Host   string
-	Client *http.Client
+	Port     int
+	Host     string
+	User     string
+	Password string
+	Client   *http.Client
 }
 
 type PrometheusQueryFetcher interface {
@@ -19,11 +21,13 @@ type PrometheusQueryFetcher interface {
 }
 
 // NewPrometheusQuery create a NewPrometheusQuery
-func NewPrometheusQuery(host string, port int, client *http.Client) PrometheusQuery {
+func NewPrometheusQuery(host string, port int, user string, password string, client *http.Client) PrometheusQuery {
 	return PrometheusQuery{
-		Client: client,
-		Host:   host,
-		Port:   port,
+		Client:   client,
+		Host:     host,
+		Port:     port,
+		User:     user,
+		Password: password,
 	}
 }
 
@@ -33,6 +37,11 @@ func (q PrometheusQuery) Fetch(query string) (*VectorQueryResponse, error) {
 	req, reqErr := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d/api/v1/query?query=%s", q.Host, q.Port, query), nil)
 	if reqErr != nil {
 		return nil, reqErr
+	}
+
+	//Set basic auth in request if added to configuration
+	if q.User != "" && q.Password != "" {
+		req.SetBasicAuth(q.User, q.Password)
 	}
 
 	res, getErr := q.Client.Do(req)

--- a/gateway/types/readconfig.go
+++ b/gateway/types/readconfig.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"strconv"
@@ -129,6 +130,20 @@ func (ReadConfig) Read(hasEnv HasEnv) (*GatewayConfig, error) {
 		cfg.PrometheusHost = prometheusHost
 	}
 
+	prometheusUser := hasEnv.Getenv("faas_prometheus_user")
+	if len(prometheusUser) > 0 {
+		cfg.PrometheusUser = prometheusUser
+	}
+
+	prometheusPasswordFile := hasEnv.Getenv("faas_prometheus_password_secret")
+	if len(prometheusPasswordFile) > 0 {
+		content, err := ioutil.ReadFile(prometheusPasswordFile)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to read Prometheus password file: %v", err)
+		}
+		cfg.PrometheusPassword = string(content)
+	}
+
 	cfg.DirectFunctions = parseBoolValue(hasEnv.Getenv("direct_functions"))
 	cfg.DirectFunctionsSuffix = hasEnv.Getenv("direct_functions_suffix")
 
@@ -213,6 +228,12 @@ type GatewayConfig struct {
 
 	// Port to connect to Prometheus.
 	PrometheusPort int
+
+	// User to authenticate with Prometheus.
+	PrometheusUser string
+
+	// Password to authenticate with Prometheus.
+	PrometheusPassword string
 
 	// If set to true we will access upstream functions directly rather than through the upstream provider
 	DirectFunctions bool


### PR DESCRIPTION
## Description
Prometheus allows you to secure the web UI and API behind basic authorization. OpenFaas currently does support using self-managed Prometheus instances, but not ones locked behind basic auth. This adds support for configuring them. The username is supplied as an environment variable for the gateway container, and then the path to a kubernetes secret file containing the password can also be supplied.

See Issue: #1660

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
Updated and then ran unit tests.

This change should not affect existing configurations without basic auth, however, to test the addition of basic auth, one could stand up a Prometheus instance with basic auth credentials and then configure two optional variables in the gateway container's environment variables containing the username, and the path to a password file, which should be volumeMounted from a Kubernetes secret.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Note: I was unable to find any existing documentation regarding the configuration for a custom prometheus host and port, which tells me that the documentation is not required. If it is required, perhaps we could discuss how to best clean up what appears to be some documentation debt :)

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
