### PR TITLE
Passing X-Original-Method and X-Original-URI to external auth

### DIFF
--- a/gateway/handlers/external_auth.go
+++ b/gateway/handlers/external_auth.go
@@ -15,6 +15,9 @@ func MakeExternalAuthHandler(next http.HandlerFunc, upstreamTimeout time.Duratio
 
 		copyHeaders(req.Header, &r.Header)
 
+		req.Header.Set("X-Original-Method", r.Method)
+		req.Header.Set("X-Original-URI", r.RequestURI)
+
 		deadlineContext, cancel := context.WithTimeout(
 			context.Background(),
 			upstreamTimeout)


### PR DESCRIPTION
Hi. I have added passing 2 custom HTTP headers to external auth call. 
- X-Original-Method
- X-Original-URI

It could be very useful if someone wants to check ACL by RESTful endpoints on their own external auth services.
For example nginx have similar function called *auth_request*: https://nginx.org/en/docs/http/ngx_http_auth_request_module.html
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
