### PR TITLE
Implement Single Flight queries for the backend

### DIFF
--- a/gateway/Makefile
+++ b/gateway/Makefile
@@ -1,0 +1,28 @@
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+PLATFORM := "linux/amd64,linux/arm/v7,linux/arm64"
+
+TAG?=latest
+SERVER?=docker.io
+OWNER?=alexellis2
+NAME=gateway
+
+.PHONY: build-local
+build-local:
+	@echo $(SERVER)/$(OWNER)/$(NAME):$(TAG) \
+	&& docker buildx create --use --name=multiarch --node multiarch \
+	&& docker buildx build \
+		--progress=plain \
+		--platform linux/amd64 \
+		--output "type=docker,push=false" \
+		--tag $(SERVER)/$(OWNER)/$(NAME):$(TAG) .
+
+.PHONY: build-push
+build-push:
+	@echo $(SERVER)/$(OWNER)/$(NAME):$(TAG) \
+	&& docker buildx create --use --name=multiarch --node multiarch \
+	&& docker buildx build \
+		--progress=plain \
+		--platform $(PLATFORM) \
+		--output "type=image,push=true" \
+		--tag $(SERVER)/$(OWNER)/$(NAME):$(TAG) .

--- a/gateway/scaling/single.go
+++ b/gateway/scaling/single.go
@@ -1,0 +1,73 @@
+package scaling
+
+import (
+	"log"
+	"sync"
+)
+
+type Call struct {
+	wg  *sync.WaitGroup
+	res *SingleFlightResult
+}
+
+type SingleFlight struct {
+	lock  *sync.RWMutex
+	calls map[string]*Call
+}
+
+type SingleFlightResult struct {
+	Result interface{}
+	Error  error
+}
+
+func NewSingleFlight() *SingleFlight {
+	return &SingleFlight{
+		lock:  &sync.RWMutex{},
+		calls: map[string]*Call{},
+	}
+}
+
+func (s *SingleFlight) Do(key string, f func() (interface{}, error)) (interface{}, error) {
+
+	s.lock.Lock()
+
+	if call, ok := s.calls[key]; ok {
+		s.lock.Unlock()
+		call.wg.Wait()
+
+		return call.res.Result, call.res.Error
+	}
+
+	var call *Call
+	if s.calls[key] == nil {
+		call = &Call{
+			wg: &sync.WaitGroup{},
+		}
+		s.calls[key] = call
+	}
+
+	call.wg.Add(1)
+
+	s.lock.Unlock()
+
+	go func() {
+		log.Printf("Miss, so running: %s", key)
+		res, err := f()
+
+		s.lock.Lock()
+		call.res = &SingleFlightResult{
+			Result: res,
+			Error:  err,
+		}
+
+		call.wg.Done()
+
+		delete(s.calls, key)
+
+		s.lock.Unlock()
+	}()
+
+	call.wg.Wait()
+
+	return call.res.Result, call.res.Error
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Implement Single Flight queries for the backend

## Motivation and Context

The gateway can cause a thundering herd problem when many concurrent requests come in at once, and a function is scaled to zero replicas. Each requests the amount of replicas, each tries to scale to the minimum amount of replicas, and each will then poll for readiness.

The changes in this PR mitigate this by capturing any subsequent calls and returning the same value for all invocations that come in before the first call finishes.

The code is based upon the unofficial library from the Go team, and I may switch out for their code before final testing and merge. https://github.com/golang/sync/blob/0de741cfad7ff3874b219dfbc1b9195b58c7c490/singleflight/singleflight.go#L139

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
arkade install openfaas --set gateway.image=docker.io/alexellis2/gateway:single14

kubectl scale -n openfaas-fn deploy/env --replicas=0
```

Then I started some monitoring, and also set up a hey test with a high level of concurrency.

```bash

stern -n openfaas gateway.* -c faas-netes --since 1m|grep -v took

stern -n openfaas gateway.* -c gateway --since 5s

hey -c 300 -z 5s http://127.0.0.1:8080/function/env
```

You'll see far fewer requests reaching the provider, than with the stock image today.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
