### PR TITLE
Remove OpenFaaS Pro metrics from OpenFaaS CE

### DIFF
--- a/gateway/main.go
+++ b/gateway/main.go
@@ -211,8 +211,6 @@ func main() {
 			decorateExternalAuth(faasHandlers.FunctionStatus, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)
 		faasHandlers.InfoHandler =
 			decorateExternalAuth(faasHandlers.InfoHandler, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)
-		faasHandlers.AsyncReport =
-			decorateExternalAuth(faasHandlers.AsyncReport, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)
 		faasHandlers.SecretHandler =
 			decorateExternalAuth(faasHandlers.SecretHandler, config.UpstreamTimeout, config.AuthProxyURL, config.AuthProxyPassBody)
 		faasHandlers.LogProxyHandler =
@@ -247,8 +245,6 @@ func main() {
 		r.HandleFunc("/async-function/{name:["+NameExpression+"]+}/", faasHandlers.QueuedProxy).Methods(http.MethodPost)
 		r.HandleFunc("/async-function/{name:["+NameExpression+"]+}", faasHandlers.QueuedProxy).Methods(http.MethodPost)
 		r.HandleFunc("/async-function/{name:["+NameExpression+"]+}/{params:.*}", faasHandlers.QueuedProxy).Methods(http.MethodPost)
-
-		r.HandleFunc("/system/async-report", handlers.MakeNotifierWrapper(faasHandlers.AsyncReport, forwardingNotifiers))
 	}
 
 	fs := http.FileServer(http.Dir("./assets/"))

--- a/gateway/metrics/exporter.go
+++ b/gateway/metrics/exporter.go
@@ -12,14 +12,12 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"strconv"
 	"time"
 
 	"log"
 
 	"github.com/openfaas/faas-provider/auth"
 	types "github.com/openfaas/faas-provider/types"
-	"github.com/openfaas/faas/gateway/scaling"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -48,7 +46,6 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	e.metricOptions.GatewayFunctionsHistogram.Describe(ch)
 	e.metricOptions.ServiceReplicasGauge.Describe(ch)
 	e.metricOptions.GatewayFunctionInvocationStarted.Describe(ch)
-	e.metricOptions.ServiceTargetLoadGauge.Describe(ch)
 
 	e.metricOptions.ServiceMetrics.Counter.Describe(ch)
 	e.metricOptions.ServiceMetrics.Histogram.Describe(ch)
@@ -62,7 +59,6 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.metricOptions.GatewayFunctionInvocationStarted.Collect(ch)
 
 	e.metricOptions.ServiceReplicasGauge.Reset()
-	e.metricOptions.ServiceTargetLoadGauge.Reset()
 
 	for _, service := range e.services {
 		var serviceName string
@@ -76,49 +72,9 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		e.metricOptions.ServiceReplicasGauge.
 			WithLabelValues(serviceName).
 			Set(float64(service.Replicas))
-
-		// Set minimum replicas
-		minReplicas := scaling.DefaultMinReplicas
-		if service.Labels != nil {
-			a := *service.Labels
-			if v, ok := a[scaling.MinScaleLabel]; ok && len(v) > 0 {
-				val, _ := strconv.Atoi(v)
-				minReplicas = val
-			}
-		}
-
-		e.metricOptions.ServiceMinReplicasGauge.
-			WithLabelValues(serviceName).
-			Set(float64(minReplicas))
-
-		// Set scale type
-		scaleType := scaling.DefaultTypeScale
-		if service.Labels != nil {
-			a := *service.Labels
-			if v, ok := a[scaling.ScaleTypeLabel]; ok && len(v) > 0 {
-				scaleType = v
-			}
-		}
-
-		// Set target load
-		targetScale := scaling.DefaultTargetLoad
-		if service.Labels != nil {
-			a := *service.Labels
-			if v, ok := a[scaling.TargetLoadLabel]; ok && len(v) > 0 {
-				val, _ := strconv.Atoi(v)
-				targetScale = val
-			}
-		}
-
-		e.metricOptions.ServiceTargetLoadGauge.
-			WithLabelValues(serviceName, scaleType).
-			Set(float64(targetScale))
-
 	}
 
 	e.metricOptions.ServiceReplicasGauge.Collect(ch)
-	e.metricOptions.ServiceMinReplicasGauge.Collect(ch)
-	e.metricOptions.ServiceTargetLoadGauge.Collect(ch)
 
 	e.metricOptions.ServiceMetrics.Counter.Collect(ch)
 	e.metricOptions.ServiceMetrics.Histogram.Collect(ch)

--- a/gateway/metrics/metrics.go
+++ b/gateway/metrics/metrics.go
@@ -17,9 +17,7 @@ type MetricOptions struct {
 	GatewayFunctionsHistogram        *prometheus.HistogramVec
 	GatewayFunctionInvocationStarted *prometheus.CounterVec
 
-	ServiceReplicasGauge    *prometheus.GaugeVec
-	ServiceMinReplicasGauge *prometheus.GaugeVec
-	ServiceTargetLoadGauge  *prometheus.GaugeVec
+	ServiceReplicasGauge *prometheus.GaugeVec
 
 	ServiceMetrics *ServiceMetricOptions
 }
@@ -71,24 +69,6 @@ func BuildMetricsOptions() MetricOptions {
 		[]string{"function_name"},
 	)
 
-	serviceMinReplicas := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "gateway",
-			Name:      "service_min",
-			Help:      "Minium replicas for function",
-		},
-		[]string{"function_name"},
-	)
-
-	serviceTargetLoad := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "gateway",
-			Name:      "service_target_load",
-			Help:      "Target load for function",
-		},
-		[]string{"function_name", "scaling_type"},
-	)
-
 	// For automatic monitoring and alerting (RED method)
 	histogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Subsystem: "http",
@@ -126,8 +106,6 @@ func BuildMetricsOptions() MetricOptions {
 		GatewayFunctionsHistogram:        gatewayFunctionsHistogram,
 		GatewayFunctionInvocation:        gatewayFunctionInvocation,
 		ServiceReplicasGauge:             serviceReplicas,
-		ServiceMinReplicasGauge:          serviceMinReplicas,
-		ServiceTargetLoadGauge:           serviceTargetLoad,
 		ServiceMetrics:                   serviceMetricOptions,
 		GatewayFunctionInvocationStarted: gatewayFunctionInvocationStarted,
 	}

--- a/gateway/requests/requests.go
+++ b/gateway/requests/requests.go
@@ -5,13 +5,6 @@
 // the OpenFaaS gateway REST API
 package requests
 
-// AsyncReport is the report from a function executed on a queue worker.
-type AsyncReport struct {
-	FunctionName string  `json:"name"`
-	StatusCode   int     `json:"statusCode"`
-	TimeTaken    float64 `json:"timeTaken"`
-}
-
 // DeleteFunctionRequest delete a deployed function
 type DeleteFunctionRequest struct {
 	FunctionName string `json:"functionName"`

--- a/gateway/types/handler_set.go
+++ b/gateway/types/handler_set.go
@@ -28,9 +28,6 @@ type HandlerSet struct {
 	// QueuedProxy queue work and return synchronous response
 	QueuedProxy http.HandlerFunc
 
-	// AsyncReport report a deferred execution result
-	AsyncReport http.HandlerFunc
-
 	// ScaleFunction enables a function to be scaled
 	ScaleFunction http.HandlerFunc
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alex@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Remove OpenFaaS Pro metrics from OpenFaaS CE

## Motivation and Context

* Removes service min and target metrics from the CE gateway

OpenFaaS Pro metrics are no longer required in OpenFaaS CE since there is an OpenFaaS Pro gateway available.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Building and running the local tests.

