### PR TITLE
Use write interceptor from faas-provider

### DIFF
--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/openfaas/faas/gateway
 
-go 1.17
+go 1.18
 
 require (
 	github.com/docker/distribution v2.8.1+incompatible

--- a/gateway/handlers/notifier_handler.go
+++ b/gateway/handlers/notifier_handler.go
@@ -6,50 +6,21 @@ package handlers
 import (
 	"net/http"
 	"time"
+
+	"github.com/openfaas/faas-provider/httputil"
 )
 
 // MakeNotifierWrapper wraps a http.HandlerFunc in an interceptor to pass to HTTPNotifier
 func MakeNotifierWrapper(next http.HandlerFunc, notifiers []HTTPNotifier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		then := time.Now()
-
-		writer := newWriteInterceptor(w)
-		next(&writer, r)
-
 		url := r.URL.String()
+
+		writer := httputil.NewHttpWriteInterceptor(w)
+		next(writer, r)
+
 		for _, notifier := range notifiers {
 			notifier.Notify(r.Method, url, url, writer.Status(), "completed", time.Since(then))
 		}
 	}
-}
-
-func newWriteInterceptor(w http.ResponseWriter) writeInterceptor {
-	return writeInterceptor{
-		w: w,
-	}
-}
-
-type writeInterceptor struct {
-	CapturedStatusCode int
-	w                  http.ResponseWriter
-}
-
-func (c *writeInterceptor) Status() int {
-	if c.CapturedStatusCode == 0 {
-		return http.StatusOK
-	}
-	return c.CapturedStatusCode
-}
-
-func (c *writeInterceptor) Header() http.Header {
-	return c.w.Header()
-}
-
-func (c *writeInterceptor) Write(data []byte) (int, error) {
-	return c.w.Write(data)
-}
-
-func (c *writeInterceptor) WriteHeader(code int) {
-	c.CapturedStatusCode = code
-	c.w.WriteHeader(code)
 }

--- a/gateway/vendor/github.com/openfaas/faas-provider/httputil/write_interceptor.go
+++ b/gateway/vendor/github.com/openfaas/faas-provider/httputil/write_interceptor.go
@@ -1,0 +1,57 @@
+package httputil
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+)
+
+func NewHttpWriteInterceptor(w http.ResponseWriter) *HttpWriteInterceptor {
+	return &HttpWriteInterceptor{w, 0}
+}
+
+type HttpWriteInterceptor struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (c *HttpWriteInterceptor) Status() int {
+	if c.statusCode == 0 {
+		return http.StatusOK
+	}
+	return c.statusCode
+}
+
+func (c *HttpWriteInterceptor) Header() http.Header {
+	return c.ResponseWriter.Header()
+}
+
+func (c *HttpWriteInterceptor) Write(data []byte) (int, error) {
+	if c.statusCode == 0 {
+		c.WriteHeader(http.StatusOK)
+	}
+	return c.ResponseWriter.Write(data)
+}
+
+func (c *HttpWriteInterceptor) WriteHeader(code int) {
+	c.statusCode = code
+	c.ResponseWriter.WriteHeader(code)
+}
+
+func (c *HttpWriteInterceptor) Flush() {
+	fl := c.ResponseWriter.(http.Flusher)
+	fl.Flush()
+}
+
+func (c *HttpWriteInterceptor) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj := c.ResponseWriter.(http.Hijacker)
+	return hj.Hijack()
+}
+
+func (c *HttpWriteInterceptor) CloseNotify() <-chan bool {
+	notifier, ok := c.ResponseWriter.(http.CloseNotifier)
+	if ok == false {
+		return nil
+	}
+	return notifier.CloseNotify()
+}

--- a/gateway/vendor/github.com/openfaas/faas-provider/httputil/writers.go
+++ b/gateway/vendor/github.com/openfaas/faas-provider/httputil/writers.go
@@ -1,0 +1,12 @@
+package httputil
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Errorf sets the response status code and write formats the provided message as the
+// response body
+func Errorf(w http.ResponseWriter, statusCode int, msg string, args ...interface{}) {
+	http.Error(w, fmt.Sprintf(msg, args...), statusCode)
+}

--- a/gateway/vendor/modules.txt
+++ b/gateway/vendor/modules.txt
@@ -40,6 +40,7 @@ github.com/nats-io/stan.go/pb
 # github.com/openfaas/faas-provider v0.19.1
 ## explicit; go 1.17
 github.com/openfaas/faas-provider/auth
+github.com/openfaas/faas-provider/httputil
 github.com/openfaas/faas-provider/types
 # github.com/openfaas/nats-queue-worker v0.0.0-20220805080536-d1d72d857b1c
 ## explicit; go 1.16


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alex@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Use write interceptor from faas-provider

## Motivation and Context

We now have two write interceptors, with one moved into faas-provider. This commit makes the gateway use the new external package and deletes its own.

## How Has This Been Tested?

Used by @welteki e2e within a cluster under load from hey.

This change is also going into the OpenFaaS Pro gateway

## Types of changes

Consolidation / maintenance 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
