### PR TITLE
fix: use io.ReadAll  replace ioutil.ReadAll

### DIFF
--- a/gateway/handlers/infohandler.go
+++ b/gateway/handlers/infohandler.go
@@ -5,10 +5,9 @@ package handlers
 
 import (
 	"encoding/json"
+	"io"
 	"log"
 	"net/http"
-
-	"io/ioutil"
 	"net/http/httptest"
 
 	providerTypes "github.com/openfaas/faas-provider/types"
@@ -27,7 +26,7 @@ func MakeInfoHandler(h http.Handler) http.HandlerFunc {
 
 		var provider *providerTypes.ProviderInfo
 
-		upstreamBody, _ := ioutil.ReadAll(upstreamCall.Body)
+		upstreamBody, _ := io.ReadAll(upstreamCall.Body)
 		err := json.Unmarshal(upstreamBody, &provider)
 		if err != nil {
 			log.Printf("Error unmarshalling provider json from body %s. Error %s\n", upstreamBody, err.Error())


### PR DESCRIPTION
ioutil.ReadAll will delete in future

Signed-off-by: 流雨声 <212724256@qq.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
