### PR TITLE
Probe on readiness only

### DIFF
--- a/gateway/probing/prober.go
+++ b/gateway/probing/prober.go
@@ -66,10 +66,10 @@ func (f *FunctionHTTPProber) Probe(functionName, namespace string) FunctionProbe
 	start := time.Now()
 
 	cachedResponse, _ := f.Query.Get(functionName, namespace)
-	probePath := "/_/health"
+	probePath := "/_/ready"
 
 	if cachedResponse.Annotations != nil {
-		if v, ok := (*cachedResponse.Annotations)["com.openfaas.http.path"]; ok && len(v) > 0 {
+		if v, ok := (*cachedResponse.Annotations)["com.openfaas.ready.http.path"]; ok && len(v) > 0 {
 			probePath = v
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Probe on readiness only

## Motivation and Context

The previous annotation used liveness, and an incorrect annotation to look up a custom path.

This feature won't work with older watchdog versions which don't yet have readiness, or older function images, so will require functions to be updated.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The original code was tested using the health endpoint

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

