### PR TITLE
docs: add missing namespace field to the scale request

### DIFF
--- a/api-docs/spec.openapi.yml
+++ b/api-docs/spec.openapi.yml
@@ -908,6 +908,7 @@ components:
     ScaleServiceRequest:
       required:
       - serviceName
+      - namespace
       - replicas
       type: object
       properties:
@@ -915,6 +916,10 @@ components:
           type: string
           description: Name of deployed function
           example: nodeinfo
+        namespace:
+          type: string
+          description: Namespace the function is deployed to.
+          example: openfaas-fn
         replicas:
           type: integer
           format: int64


### PR DESCRIPTION
The ScaleFunction request supports specifying the function namespace. This is now included in the API spec.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label

This issue was discussed during the last Community call

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
NA


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
