### PR TITLE
Update the link to the api docs

### DIFF
--- a/api-docs/README.md
+++ b/api-docs/README.md
@@ -1,11 +1,11 @@
 ## Exploring or editing the Swagger API documentation
 
-The `swagger.yml` file can be viewed and edited in the Swagger UI.
+The `spec.openapi.yml` file can be viewed and edited in the Swagger UI.
 
 * Head over to the [Swagger editor](http://editor.swagger.io/)
 
 * Now click File -> Import URL
 
-* Type in `https://raw.githubusercontent.com/openfaas/faas/master/api-docs/swagger.yml` and click OK
+* Type in `https://raw.githubusercontent.com/openfaas/faas/master/api-docs/spec.openapi.yml` and click OK
 
 You can now view and edit the Swagger, copy back to your fork before pushing changes.


### PR DESCRIPTION
The README.md under fass/api-docs has an incorrect URL to the api spec file. This change updates it.

Fixes #1826

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I imported the updated link in swagger and the api docs show up as expected.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
