### PR TITLE
Set default user agent in proxy client

### DIFF
--- a/gateway/types/proxy_client.go
+++ b/gateway/types/proxy_client.go
@@ -4,10 +4,13 @@
 package types
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/openfaas/faas/gateway/version"
 )
 
 // NewHTTPClientReverseProxy proxies to an upstream host through the use of a http.Client
@@ -31,18 +34,20 @@ func NewHTTPClientReverseProxy(baseURL *url.URL, timeout time.Duration, maxIdleC
 	// https://github.com/minio/minio/pull/5860
 
 	// Taken from http.DefaultTransport in Go 1.11
-	h.Client.Transport = &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   timeout,
-			KeepAlive: timeout,
-			DualStack: true,
-		}).DialContext,
-		MaxIdleConns:          maxIdleConns,
-		MaxIdleConnsPerHost:   maxIdleConnsPerHost,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
+	h.Client.Transport = &proxyTransport{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   timeout,
+				KeepAlive: timeout,
+				DualStack: true,
+			}).DialContext,
+			MaxIdleConns:          maxIdleConns,
+			MaxIdleConnsPerHost:   maxIdleConnsPerHost,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
 	}
 
 	return &h
@@ -53,4 +58,20 @@ type HTTPClientReverseProxy struct {
 	BaseURL *url.URL
 	Client  *http.Client
 	Timeout time.Duration
+}
+
+// proxyTransport is an http.RoundTripper for the reverse proxy client.
+// It ensures default headers like the `User-Agent` are set on requests.
+type proxyTransport struct {
+	// Transport is the underlying HTTP transport to use when making requests.
+	Transport http.RoundTripper
+}
+
+// RoundTrip implements the RoundTripper interface.
+func (t *proxyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if _, ok := req.Header["User-Agent"]; !ok {
+		req.Header.Set("User-Agent", fmt.Sprintf("openfaas-ce-gateway/%s", version.BuildVersion()))
+	}
+
+	return t.Transport.RoundTrip(req)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Set a default user agent for the http proxy client, `openfaas-ce-gateway/<version>` if the proxied request does not have the `User-Agent` header.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label

The gateway used to inject the default golang user agent, `Go-http-client/1.1`, into requests. This change ensures the default user agent is set correctly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the gateway user agent header is injected if a request does not contain a user agent header.

```sh
curl -i "http://127.0.0.1:8001/function/env" -H "User-Agent:"

TTP/1.1 200 OK
Content-Length: 994
Content-Type: text/plain; charset=utf-8
Date: Tue, 06 Aug 2024 13:56:26 GMT
X-Call-Id: 38929e79-5e13-4369-a9d1-93a71101a058
X-Duration-Seconds: 0.000604
X-Served-By: openfaas-community/
X-Start-Time: 1722952586671966988

...
Http_User_Agent=openfaas-ce-gateway/dev
...
```

Verified the user agent from the original request is forwarded.

```sh
curl -i "http://127.0.0.1:8001/function/env"      
HTTP/1.1 200 OK
Content-Length: 982
Content-Type: text/plain; charset=utf-8
Date: Tue, 06 Aug 2024 13:55:37 GMT
X-Call-Id: 5719114d-1032-41ae-87ac-813eefcc4019
X-Duration-Seconds: 0.000715
X-Served-By: openfaas-community/
X-Start-Time: 1722952537702282995

...
Http_User_Agent=curl/7.81.0
...
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
